### PR TITLE
[Feature/#7] 로봇용 Embedded Browser OAuth 로그인 구현

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,10 @@
 services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    restart: unless-stopped
+
   postgres:
     image: postgres:16
     ports:
@@ -16,10 +22,12 @@ services:
       - "8000:8000"
     environment:
       DATABASE_URL: postgresql+asyncpg://robot_studio:robot_studio@postgres:5432/robot_studio
+      REDIS_URL: redis://redis:6379 
     env_file:
       - ./server/.env
     depends_on:
       - postgres
+      - redis
     volumes:
       - ./server/app:/app/app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,8 @@ services:
       - redis
     volumes:
       - ./server/app:/app/app
+      - ./server/tests:/app/tests
+      - ./server/pytest.ini:/app/pytest.ini
 
   web:
     build: ./web

--- a/robot/Dockerfile
+++ b/robot/Dockerfile
@@ -24,6 +24,20 @@ RUN apt-get update && apt-get install -y \
     libfontconfig1 \
     libdbus-1-3 \
     python3-pip \
+    libnss3 \
+    libnspr4 \
+    libxkbfile1 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxrandr2 \
+    libxtst6 \
+    libxss1 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libdrm2 \
+    libgbm1 \
+    libasound2 \
     && rm -rf /var/lib/apt/lists/*
 
 # 한글 폰트 설치

--- a/robot/Dockerfile
+++ b/robot/Dockerfile
@@ -2,6 +2,7 @@ FROM ros:humble-ros-base
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DISPLAY=unix:0
+ENV QTWEBENGINE_CHROMIUM_FLAGS="--no-sandbox"
 
 # ROS 개발 도구 설치
 RUN apt-get update && apt-get install -y \

--- a/robot/requirements.txt
+++ b/robot/requirements.txt
@@ -11,3 +11,4 @@ python-dotenv
 fastapi
 pydantic
 st3215
+pytest-asyncio>=0.23.0

--- a/robot/src/robot_ui/package.xml
+++ b/robot/src/robot_ui/package.xml
@@ -15,6 +15,7 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>python3-pytest-asyncio</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/robot/src/robot_ui/robot_ui/utils/api_client.py
+++ b/robot/src/robot_ui/robot_ui/utils/api_client.py
@@ -8,6 +8,7 @@ class ApiClient:
         self.base_url = base_url
         self._session: aiohttp.ClientSession | None = None
         self._token: str | None = None
+        self._refresh_token: str | None = None
 
     @property
     def session(self) -> aiohttp.ClientSession:
@@ -19,8 +20,24 @@ class ApiClient:
         if self._session and not self._session.closed:
             await self._session.close()
 
-    def set_token(self, token: str) -> None:
-        self._token = token
+    def set_token(self, access_token: str, refresh_token: str) -> None:
+        self._token = access_token
+        self._refresh_token = refresh_token
+
+    async def _refresh_tokens(self) -> None:
+        if not self._refresh_token:
+            raise ValueError("refresh_token이 없습니다")
+        async with self.session.post(
+            f"{self.base_url}/api/v1/auth/refresh",
+            json={"refresh_token": self._refresh_token},
+            timeout=aiohttp.ClientTimeout(total=10),
+        ) as response:
+            if response.status == 401:
+                raise ValueError("refresh_token이 만료되었습니다")
+            response.raise_for_status()
+            data = await response.json()
+            self._token = data["access_token"]
+            self._refresh_token = data["refresh_token"]
 
     def _auth_headers(self) -> dict:
         if self._token:
@@ -41,15 +58,19 @@ class ApiClient:
 
     async def get_presigned_url(self, object_name: str) -> str:
         """단일 presigned URL 요청"""
-        async with self.session.post(
-            f"{self.base_url}/api/v1/objects/presigned-upload-url",
-            json={"object_name": object_name},
-            headers=self._auth_headers(),
-            timeout=aiohttp.ClientTimeout(total=10)
-        ) as response:
-            response.raise_for_status()
-            data = await response.json()
-            return data['url']
+        for attempt in range(2):
+            async with self.session.post(
+                f"{self.base_url}/api/v1/objects/presigned-upload-url",
+                json={"object_name": object_name},
+                headers=self._auth_headers(),
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as response:
+                if response.status == 401 and attempt == 0:
+                    await self._refresh_tokens()
+                    continue
+                response.raise_for_status()
+                data = await response.json()
+                return data["url"]
 
     async def upload_to_s3(self, presigned_url: str, video_path: str):
         """Presigned URL로 파일 업로드"""

--- a/robot/src/robot_ui/robot_ui/utils/api_client.py
+++ b/robot/src/robot_ui/robot_ui/utils/api_client.py
@@ -7,6 +7,7 @@ class ApiClient:
     def __init__(self, base_url: str = "http://localhost:8000"):
         self.base_url = base_url
         self._session: aiohttp.ClientSession | None = None
+        self._token: str | None = None
 
     @property
     def session(self) -> aiohttp.ClientSession:
@@ -18,11 +19,32 @@ class ApiClient:
         if self._session and not self._session.closed:
             await self._session.close()
 
+    def set_token(self, token: str) -> None:
+        self._token = token
+
+    def _auth_headers(self) -> dict:
+        if self._token:
+            return {"Authorization": f"Bearer {self._token}"}
+        return {}
+
+    async def exchange_code(self, code: str) -> dict:
+        """서버에 1회용 코드를 제출하고 토큰을 교환"""
+        async with self.session.post(
+            f"{self.base_url}/api/v1/auth/token-exchange",
+            params={"code": code},
+            timeout=aiohttp.ClientTimeout(total=10),
+        ) as response:
+            if response.status == 401:
+                raise ValueError("유효하지 않거나 만료된 코드입니다")
+            response.raise_for_status()
+            return await response.json()
+
     async def get_presigned_url(self, object_name: str) -> str:
         """단일 presigned URL 요청"""
         async with self.session.post(
             f"{self.base_url}/api/v1/objects/presigned-upload-url",
             json={"object_name": object_name},
+            headers=self._auth_headers(),
             timeout=aiohttp.ClientTimeout(total=10)
         ) as response:
             response.raise_for_status()

--- a/robot/src/robot_ui/robot_ui/views/main_window.py
+++ b/robot/src/robot_ui/robot_ui/views/main_window.py
@@ -1,6 +1,8 @@
-from PySide6.QtWidgets import QMainWindow, QWidget, QHBoxLayout
+import asyncio
+from PySide6.QtWidgets import QMainWindow, QWidget, QHBoxLayout, QStackedWidget
 from rclpy.logging import get_logger
-from ..widgets import Sidebar, CameraPreviewArea, DatasetSettingPanel, DataCollectionPanel, TeleopPanel
+from ..widgets import Sidebar, CameraPreviewArea, DatasetSettingPanel, DataCollectionPanel, TeleopPanel, LoginWebView
+from ..utils.api_client import ApiClient
 
 logger = get_logger('MainWindow')
 
@@ -21,13 +23,21 @@ class MainWindow(QMainWindow):
             }
         """)
 
+        self.api_client = ApiClient()
         self._setup_ui()
 
     def _setup_ui(self):
-        central_widget = QWidget()
-        self.setCentralWidget(central_widget)
+        self.stacked_widget = QStackedWidget()
+        self.setCentralWidget(self.stacked_widget)
 
-        main_layout = QHBoxLayout(central_widget)
+        # 페이지 0: 로그인
+        self.login_webview = LoginWebView()
+        self.login_webview.login_success.connect(self._on_login_success)
+        self.stacked_widget.addWidget(self.login_webview)  # index 0
+
+        # 페이지 1: 메인
+        main_page = QWidget()
+        main_layout = QHBoxLayout(main_page)
         main_layout.setContentsMargins(0, 0, 0, 0)
         main_layout.setSpacing(0)
 
@@ -63,6 +73,24 @@ class MainWindow(QMainWindow):
         self.empty_area = QWidget()
         self.empty_area.setStyleSheet("background-color: #1e1e1e;")
         main_layout.addWidget(self.empty_area, 1)
+
+        self.stacked_widget.addWidget(main_page)  # index 1
+        self.stacked_widget.setCurrentIndex(0)
+
+    def _on_login_success(self, code: str):
+        asyncio.create_task(self._exchange_and_login(code))
+
+    async def _exchange_and_login(self, code: str):
+        try:
+            tokens = await self.api_client.exchange_code(code)
+            self.api_client.set_token(tokens["access_token"])
+            self.stacked_widget.setCurrentIndex(1)
+        except ValueError:
+            logger.warning("Code exchange failed: invalid or expired code")
+            self.login_webview.reset()
+        except Exception as e:
+            logger.error(f"Code exchange failed: {e}")
+            self.login_webview.reset()
 
     def _on_menu_selected(self, menu_id: str):
         # 모든 영역 숨기기
@@ -105,7 +133,7 @@ class MainWindow(QMainWindow):
         self.camera_preview_area.setVisible(False)
         self.dataset_setting_panel.setVisible(False)
         self.data_collection_panel.setVisible(True)
-        self.empty_area.setVisible(False)      
+        self.empty_area.setVisible(False)
 
     def closeEvent(self, event):
         if hasattr(self, 'teleop_panel'):

--- a/robot/src/robot_ui/robot_ui/views/main_window.py
+++ b/robot/src/robot_ui/robot_ui/views/main_window.py
@@ -83,7 +83,7 @@ class MainWindow(QMainWindow):
     async def _exchange_and_login(self, code: str):
         try:
             tokens = await self.api_client.exchange_code(code)
-            self.api_client.set_token(tokens["access_token"])
+            self.api_client.set_token(tokens["access_token"], tokens["refresh_token"])
             self.stacked_widget.setCurrentIndex(1)
         except ValueError:
             logger.warning("Code exchange failed: invalid or expired code")

--- a/robot/src/robot_ui/robot_ui/widgets/__init__.py
+++ b/robot/src/robot_ui/robot_ui/widgets/__init__.py
@@ -3,5 +3,6 @@ from .camera_preview import CameraPreviewArea
 from .dataset_setting import DatasetSettingPanel
 from .data_collection import DataCollectionPanel
 from .teleop_panel import TeleopPanel
+from .login_webview import LoginWebView
 
-__all__ = ['Sidebar', 'CameraPreviewArea', 'DatasetSettingPanel', 'DataCollectionPanel', 'TeleopPanel']
+__all__ = ['Sidebar', 'CameraPreviewArea', 'DatasetSettingPanel', 'DataCollectionPanel', 'TeleopPanel', 'LoginWebView']

--- a/robot/src/robot_ui/robot_ui/widgets/login_webview.py
+++ b/robot/src/robot_ui/robot_ui/widgets/login_webview.py
@@ -1,0 +1,37 @@
+from PySide6.QtWidgets import QWidget, QVBoxLayout
+from PySide6.QtWebEngineWidgets import QWebEngineView
+from PySide6.QtCore import Signal, QUrl
+from urllib.parse import urlparse, parse_qs
+
+
+class LoginWebView(QWidget):
+    """Embedded Browser 기반 로그인 위젯"""
+
+    login_success = Signal(str)  # (code,) — 토큰이 아닌 1회용 코드 전달
+
+    def __init__(self, login_url: str = "http://localhost:3000/login?from=robot"):
+        super().__init__()
+        self._login_url = login_url
+        self._setup_ui()
+
+    def _setup_ui(self):
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        self.web_view = QWebEngineView()
+        self.web_view.setUrl(QUrl(self._login_url))
+        self.web_view.urlChanged.connect(self._on_url_changed)
+        layout.addWidget(self.web_view)
+
+    def _on_url_changed(self, url: QUrl):
+        """URL 변경 감지 — /auth/callback 도달 시 code 추출"""
+        parsed = urlparse(url.toString())
+        if parsed.path == "/auth/callback":
+            params = parse_qs(parsed.query)
+            code = params.get("code", [None])[0]
+            if code:
+                self.login_success.emit(code)
+
+    def reset(self):
+        """로그인 실패/로그아웃 시 초기화"""
+        self.web_view.setUrl(QUrl(self._login_url))

--- a/robot/src/robot_ui/setup.cfg
+++ b/robot/src/robot_ui/setup.cfg
@@ -2,3 +2,6 @@
 script_dir=$base/lib/robot_ui
 [install]
 install_scripts=$base/lib/robot_ui
+
+[tool:pytest]
+asyncio_mode = auto

--- a/robot/src/robot_ui/setup.py
+++ b/robot/src/robot_ui/setup.py
@@ -10,7 +10,7 @@ setup(
         ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
     ],
-    install_requires=['setuptools', 'aiohttp', 'qasync'],
+    install_requires=['setuptools', 'aiohttp', 'qasync', 'PySide6-WebEngine'],
     zip_safe=True,
     maintainer='User',
     maintainer_email='user@example.com',

--- a/robot/src/robot_ui/test/test_api_client.py
+++ b/robot/src/robot_ui/test/test_api_client.py
@@ -24,16 +24,17 @@ def make_cm(response):
 # 단위 테스트 (HTTP 없음)
 
 def test_set_token_stores_token():
-    """set_token 호출 후 _token에 값이 저장되는지 검증"""
+    """set_token 호출 후 _token, _refresh_token에 값이 저장되는지 검증"""
     client = ApiClient()
-    client.set_token("my.jwt.token")
+    client.set_token("my.jwt.token", "my.refresh.token")
     assert client._token == "my.jwt.token"
+    assert client._refresh_token == "my.refresh.token"
 
 
 def test_auth_headers_returns_bearer_when_token_set():
     """토큰이 설정된 경우 Authorization 헤더 반환"""
     client = ApiClient()
-    client.set_token("my.jwt.token")
+    client.set_token("my.jwt.token", "my.refresh.token")
     assert client._auth_headers() == {"Authorization": "Bearer my.jwt.token"}
 
 
@@ -85,7 +86,7 @@ async def test_exchange_code_sends_code_as_query_param():
 async def test_get_presigned_url_returns_url():
     """서버 응답에서 url 값을 반환하는지 검증"""
     client = ApiClient()
-    client.set_token("my.jwt.token")
+    client.set_token("my.jwt.token", "my.refresh.token")
     response = make_mock_response(
         status=200,
         json_data={"url": "https://fake-s3.example.com/upload?sig=abc"},
@@ -100,7 +101,7 @@ async def test_get_presigned_url_returns_url():
 async def test_get_presigned_url_sends_auth_header():
     """요청에 Authorization 헤더가 포함되는지 검증"""
     client = ApiClient()
-    client.set_token("my.jwt.token")
+    client.set_token("my.jwt.token", "my.refresh.token")
     response = make_mock_response(
         status=200,
         json_data={"url": "https://fake-s3.example.com/upload?sig=abc"},
@@ -126,3 +127,63 @@ async def test_get_presigned_url_without_token_sends_no_auth_header():
         await client.get_presigned_url("episode_001.mp4")
 
     assert mock_post.call_args[1]["headers"] == {}
+
+
+# _refresh_tokens 테스트
+
+async def test_refresh_tokens_updates_tokens():
+    """refresh 성공 시 _token, _refresh_token이 갱신되는지 검증"""
+    client = ApiClient()
+    client.set_token("old.access", "old.refresh")
+    response = make_mock_response(
+        status=200,
+        json_data={"access_token": "new.access", "refresh_token": "new.refresh"},
+    )
+
+    with patch.object(client.session, "post", return_value=make_cm(response)):
+        await client._refresh_tokens()
+
+    assert client._token == "new.access"
+    assert client._refresh_token == "new.refresh"
+
+
+async def test_refresh_tokens_raises_on_401():
+    """refresh_token 만료(401) 시 ValueError 발생"""
+    client = ApiClient()
+    client.set_token("old.access", "expired.refresh")
+    response = make_mock_response(status=401)
+
+    with patch.object(client.session, "post", return_value=make_cm(response)):
+        with pytest.raises(ValueError):
+            await client._refresh_tokens()
+
+
+async def test_refresh_tokens_raises_without_refresh_token():
+    """refresh_token 미설정 시 ValueError 발생"""
+    client = ApiClient()
+    with pytest.raises(ValueError):
+        await client._refresh_tokens()
+
+
+async def test_get_presigned_url_retries_after_401():
+    """401 응답 시 토큰 갱신 후 재시도하여 URL을 반환하는지 검증"""
+    client = ApiClient()
+    client.set_token("old.access", "old.refresh")
+
+    unauthorized = make_mock_response(status=401)
+    success = make_mock_response(
+        status=200,
+        json_data={"url": "https://fake-s3.example.com/upload?sig=xyz"},
+    )
+    mock_post = MagicMock(side_effect=[make_cm(unauthorized), make_cm(success)])
+    refresh_response = make_mock_response(
+        status=200,
+        json_data={"access_token": "new.access", "refresh_token": "new.refresh"},
+    )
+
+    with patch.object(client.session, "post", mock_post):
+        with patch.object(client, "_refresh_tokens", AsyncMock(side_effect=lambda: setattr(client, "_token", "new.access") or None)):
+            url = await client.get_presigned_url("episode_001.mp4")
+
+    assert url == "https://fake-s3.example.com/upload?sig=xyz"
+    assert mock_post.call_count == 2

--- a/robot/src/robot_ui/test/test_api_client.py
+++ b/robot/src/robot_ui/test/test_api_client.py
@@ -1,0 +1,128 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from robot_ui.utils.api_client import ApiClient
+
+
+def make_mock_response(status=200, json_data=None):
+    """aiohttp response mock 헬퍼"""
+    response = MagicMock()
+    response.status = status
+    response.json = AsyncMock(return_value=json_data or {})
+    response.raise_for_status = MagicMock()
+    return response
+
+
+def make_cm(response):
+    """aiohttp async context manager mock 헬퍼"""
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=response)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+# 단위 테스트 (HTTP 없음)
+
+def test_set_token_stores_token():
+    """set_token 호출 후 _token에 값이 저장되는지 검증"""
+    client = ApiClient()
+    client.set_token("my.jwt.token")
+    assert client._token == "my.jwt.token"
+
+
+def test_auth_headers_returns_bearer_when_token_set():
+    """토큰이 설정된 경우 Authorization 헤더 반환"""
+    client = ApiClient()
+    client.set_token("my.jwt.token")
+    assert client._auth_headers() == {"Authorization": "Bearer my.jwt.token"}
+
+
+def test_auth_headers_returns_empty_when_no_token():
+    """토큰이 없으면 빈 dict 반환"""
+    client = ApiClient()
+    assert client._auth_headers() == {}
+
+
+# exchange_code 테스트
+
+async def test_exchange_code_returns_token_dict():
+    """유효한 code → access_token, refresh_token 포함된 dict 반환"""
+    client = ApiClient()
+    token_data = {"access_token": "acc.tok", "refresh_token": "ref.tok"}
+    response = make_mock_response(status=200, json_data=token_data)
+
+    with patch.object(client.session, "post", return_value=make_cm(response)):
+        result = await client.exchange_code("valid-code-abc")
+
+    assert result["access_token"] == "acc.tok"
+    assert result["refresh_token"] == "ref.tok"
+
+
+async def test_exchange_code_raises_on_401():
+    """서버가 401 반환 → ValueError 발생"""
+    client = ApiClient()
+    response = make_mock_response(status=401)
+
+    with patch.object(client.session, "post", return_value=make_cm(response)):
+        with pytest.raises(ValueError):
+            await client.exchange_code("expired-code")
+
+
+async def test_exchange_code_sends_code_as_query_param():
+    """code가 query param으로 전달되는지 검증"""
+    client = ApiClient()
+    response = make_mock_response(status=200, json_data={"access_token": "a", "refresh_token": "b"})
+    mock_post = MagicMock(return_value=make_cm(response))
+
+    with patch.object(client.session, "post", mock_post):
+        await client.exchange_code("test-code-xyz")
+
+    assert mock_post.call_args[1]["params"] == {"code": "test-code-xyz"}
+
+
+# get_presigned_url 테스트
+
+async def test_get_presigned_url_returns_url():
+    """서버 응답에서 url 값을 반환하는지 검증"""
+    client = ApiClient()
+    client.set_token("my.jwt.token")
+    response = make_mock_response(
+        status=200,
+        json_data={"url": "https://fake-s3.example.com/upload?sig=abc"},
+    )
+
+    with patch.object(client.session, "post", return_value=make_cm(response)):
+        url = await client.get_presigned_url("episode_001.mp4")
+
+    assert url == "https://fake-s3.example.com/upload?sig=abc"
+
+
+async def test_get_presigned_url_sends_auth_header():
+    """요청에 Authorization 헤더가 포함되는지 검증"""
+    client = ApiClient()
+    client.set_token("my.jwt.token")
+    response = make_mock_response(
+        status=200,
+        json_data={"url": "https://fake-s3.example.com/upload?sig=abc"},
+    )
+    mock_post = MagicMock(return_value=make_cm(response))
+
+    with patch.object(client.session, "post", mock_post):
+        await client.get_presigned_url("episode_001.mp4")
+
+    assert mock_post.call_args[1]["headers"] == {"Authorization": "Bearer my.jwt.token"}
+
+
+async def test_get_presigned_url_without_token_sends_no_auth_header():
+    """토큰 없이 요청 시 Authorization 헤더가 없는지 검증"""
+    client = ApiClient()
+    response = make_mock_response(
+        status=200,
+        json_data={"url": "https://fake-s3.example.com/upload?sig=abc"},
+    )
+    mock_post = MagicMock(return_value=make_cm(response))
+
+    with patch.object(client.session, "post", mock_post):
+        await client.get_presigned_url("episode_001.mp4")
+
+    assert mock_post.call_args[1]["headers"] == {}

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,3 +1,4 @@
 AWS_DEFAULT_REGION=ap-northeast-2
 AWS_ACCESS_KEY_ID=your-access-key-id
 AWS_SECRET_ACCESS_KEY=your-secret-access-key
+REDIS_URL=redis://localhost:6379

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,8 +2,8 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+COPY requirements.txt requirements-test.txt ./
+RUN pip install --no-cache-dir -r requirements.txt -r requirements-test.txt
 
 COPY app/ ./app/
 

--- a/server/app/api/v1/auth.py
+++ b/server/app/api/v1/auth.py
@@ -69,3 +69,15 @@ async def issue_code(
 ):
     code = await service.issue_code(str(current_user.id), redis)
     return {"code": code}
+
+@router.post("/token-exchange")
+async def token_exchange(
+    code: str,
+    service: AuthService = Depends(get_auth_service),
+    redis=Depends(get_redis),
+):
+    try:
+        access_token, refresh_token = await service.exchange_code(code, redis)
+        return {"access_token": access_token, "refresh_token": refresh_token}
+    except ValueError as e:
+        raise HTTPException(status_code=401, detail=str(e))

--- a/server/app/api/v1/auth.py
+++ b/server/app/api/v1/auth.py
@@ -1,12 +1,37 @@
 from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from jose import JWTError
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.infra.database import get_db
 from app.services.auth_service import AuthService
-from app.schemas.auth import SignupRequest, SignupResponse, TokenResponse, RefreshRequest, LoginRequest
+from app.core.security import decode_access_token
+from app.core.redis import get_redis
+from app.models.user import User
+from app.schemas.auth import SignupRequest, SignupResponse, TokenResponse, RefreshRequest, LoginRequest, UserResponse, AuthCodeResponse
 router = APIRouter(prefix="/auth", tags=["auth"])
+
+security_scheme = HTTPBearer()
 
 def get_auth_service(db: AsyncSession = Depends(get_db)) -> AuthService:
     return AuthService(db)
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security_scheme),
+    db: AsyncSession = Depends(get_db),
+) -> User:
+    try:
+        payload = decode_access_token(credentials.credentials)
+        user_id = payload.get("sub")
+        if user_id is None:
+            raise HTTPException(status_code=401, detail="Invalid token")
+    except JWTError:
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+    if user is None:
+        raise HTTPException(status_code=401, detail="User not found")
+    return user
 
 @router.post("/signup", response_model=SignupResponse, status_code=status.HTTP_201_CREATED)
 async def signup(req: SignupRequest, service: AuthService = Depends(get_auth_service)):
@@ -31,3 +56,16 @@ async def refresh(req: RefreshRequest, service: AuthService = Depends(get_auth_s
         return TokenResponse(access_token=access_token, refresh_token=refresh_token)
     except ValueError as e:
         raise HTTPException(status_code=401, detail=str(e))
+
+@router.get("/me", response_model=UserResponse)
+async def get_me(current_user: User = Depends(get_current_user)):
+    return current_user
+
+@router.post("/issue-code", response_model=AuthCodeResponse)
+async def issue_code(
+    current_user: User = Depends(get_current_user),
+    service: AuthService = Depends(get_auth_service),
+    redis=Depends(get_redis),
+):
+    code = await service.issue_code(str(current_user.id), redis)
+    return {"code": code}

--- a/server/app/api/v1/objects.py
+++ b/server/app/api/v1/objects.py
@@ -3,6 +3,8 @@ from fastapi import APIRouter, HTTPException, Depends
 from app.schemas.object import PresignedUploadUrlRequest, PresignedUrlResponse
 from app.services.object_service import ObjectService
 from app.infra.s3 import get_s3_client
+from app.api.v1.auth import get_current_user
+from app.models.user import User
 
 router = APIRouter(prefix="/objects", tags=["objects"])
 
@@ -16,6 +18,7 @@ def get_object_service(
 @router.post("/presigned-upload-url", response_model=PresignedUrlResponse)
 async def get_upload_url(
     request: PresignedUploadUrlRequest,
+    current_user: User = Depends(get_current_user),
     service: ObjectService = Depends(get_object_service)
 ):
     try:

--- a/server/app/core/config.py
+++ b/server/app/core/config.py
@@ -15,5 +15,6 @@ class Settings(BaseSettings):
 
     class Config:
         env_file = ".env"
+        extra = "ignore"
 
 settings = Settings()

--- a/server/app/core/config.py
+++ b/server/app/core/config.py
@@ -1,8 +1,12 @@
 from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
+    # S3 CONFIGURATION
     S3_BUCKET_NAME: str = "lerobot-soarm-dataset"
-    PRESIGNED_URL_EXPIRE_MINUTES: int = 10
+    PRESIGNED_URL_EXPIRE_MINUTES: int = 10   
+
+    # REDIS CONFIGURATION
+    REDIS_URL: str
 
     #DATABASE CONFIGURATION
     DATABASE_URL: str = "postgresql+asyncpg://robot_studio:robot_studio@localhost:5432/robot_studio"

--- a/server/app/core/redis.py
+++ b/server/app/core/redis.py
@@ -1,0 +1,11 @@
+import redis.asyncio as aioredis
+from app.core.config import settings
+
+redis_client: aioredis.Redis | None = None
+
+async def get_redis() -> aioredis.Redis:
+    global redis_client
+    
+    if redis_client is None:
+        redis_client = aioredis.from_url(settings.REDIS_URL, decode_responses=True)
+    return redis_client

--- a/server/app/schemas/auth.py
+++ b/server/app/schemas/auth.py
@@ -1,3 +1,5 @@
+import uuid
+
 from pydantic import BaseModel
 
 class SignupRequest(BaseModel):
@@ -20,3 +22,14 @@ class RefreshRequest(BaseModel):
 class LoginRequest(BaseModel):
     email: str
     password: str
+
+class UserResponse(BaseModel):
+    id: uuid.UUID
+    username: str | None
+    email: str
+
+    class Config:
+        from_attributes = True
+
+class AuthCodeResponse(BaseModel):
+    code: str

--- a/server/app/services/auth_service.py
+++ b/server/app/services/auth_service.py
@@ -1,4 +1,5 @@
 import hashlib
+import secrets
 from datetime import datetime, timedelta
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -72,3 +73,9 @@ class AuthService:
             raise ValueError("사용자를 찾을 수 없습니다")
 
         return await self._issue_tokens(user)
+
+    async def issue_code(self, user_id: str, redis) -> str:
+        """1회용 코드 발급 — 30초 유효"""
+        code = secrets.token_urlsafe(32)
+        await redis.setex(f"auth_code:{code}", 30, user_id)
+        return code

--- a/server/app/services/auth_service.py
+++ b/server/app/services/auth_service.py
@@ -79,3 +79,13 @@ class AuthService:
         code = secrets.token_urlsafe(32)
         await redis.setex(f"auth_code:{code}", 30, user_id)
         return code
+
+    async def exchange_code(self, code: str, redis) -> tuple[str, str]:
+        """코드를 토큰으로 교환 (코드는 즉시 삭제, refresh token DB 저장 포함)"""
+        user_id = await redis.getdel(f"auth_code:{code}")
+        if user_id is None:
+            raise ValueError("Invalid or expired code")
+        user = await self.user_repo.find_by_id(user_id)
+        if user is None:
+            raise ValueError("User not found")
+        return await self._issue_tokens(user)

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,13 +1,9 @@
 services:
   redis:
     image: redis:7-alpine
-    ports:
-      - "6379:6379"
     restart: unless-stopped
   postgres:
     image: postgres:16
-    ports:
-      - "5432:5432"
     environment:
       POSTGRES_USER: robot_studio
       POSTGRES_PASSWORD: robot_studio
@@ -29,6 +25,8 @@ services:
       - redis
     volumes:
       - ./app:/app/app
+      - ./tests:/app/tests
+      - ./pytest.ini:/app/pytest.ini
 
 volumes:
   postgres_data:

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,4 +1,9 @@
 services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    restart: unless-stopped
   postgres:
     image: postgres:16
     ports:
@@ -18,8 +23,10 @@ services:
       - .env
     environment:
       DATABASE_URL: postgresql+asyncpg://robot_studio:robot_studio@postgres:5432/robot_studio
+      REDIS_URL: redis://redis:6379 
     depends_on:
       - postgres
+      - redis
     volumes:
       - ./app:/app/app
 

--- a/server/pytest.ini
+++ b/server/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/server/requirements-test.txt
+++ b/server/requirements-test.txt
@@ -1,0 +1,5 @@
+pytest>=8.0.0
+pytest-asyncio>=0.23.0
+httpx>=0.27.0
+fakeredis[aioredis]>=2.0.0
+aiosqlite>=0.20.0

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -6,3 +6,4 @@ sqlalchemy>=2.0.0
 asyncpg>=0.30.0
 bcrypt>=4.0.0
 python-jose[cryptography]>=3.3.0
+redis[hiredis]

--- a/server/tests/api/test_auth.py
+++ b/server/tests/api/test_auth.py
@@ -61,3 +61,61 @@ async def test_issue_code_with_unknown_user_returns_401(client):
         headers={"Authorization": f"Bearer {token}"},
     )
     assert response.status_code == 401
+
+async def test_token_exchange_returns_tokens(client, db_session):
+    """유효한 code → access_token과 refresh_token 반환"""
+    user = await make_user(db_session)
+    token = create_access_token(str(user.id))
+
+    issue_resp = await client.post(
+        "/api/v1/auth/issue-code",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    code = issue_resp.json()["code"]
+
+    response = await client.post(f"/api/v1/auth/token-exchange?code={code}")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "access_token" in body
+    assert "refresh_token" in body
+
+
+async def test_token_exchange_code_is_one_time_use(client, db_session):
+    """같은 code를 두 번 사용하면 두 번째 요청은 401"""
+    user = await make_user(db_session)
+    token = create_access_token(str(user.id))
+
+    issue_resp = await client.post(
+        "/api/v1/auth/issue-code",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    code = issue_resp.json()["code"]
+
+    await client.post(f"/api/v1/auth/token-exchange?code={code}")
+    response = await client.post(f"/api/v1/auth/token-exchange?code={code}")
+
+    assert response.status_code == 401
+
+
+async def test_token_exchange_with_invalid_code_returns_401(client):
+    """존재하지 않는 code → 401"""
+    response = await client.post("/api/v1/auth/token-exchange?code=nonexistent_code")
+    assert response.status_code == 401
+
+
+async def test_token_exchange_code_deleted_from_redis(client, db_session, fake_redis):
+    """교환 후 Redis에서 code가 삭제되는지 검증"""
+    user = await make_user(db_session)
+    token = create_access_token(str(user.id))
+
+    issue_resp = await client.post(
+        "/api/v1/auth/issue-code",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    code = issue_resp.json()["code"]
+
+    await client.post(f"/api/v1/auth/token-exchange?code={code}")
+
+    remaining = await fake_redis.get(f"auth_code:{code}")
+    assert remaining is None

--- a/server/tests/api/test_auth.py
+++ b/server/tests/api/test_auth.py
@@ -1,0 +1,63 @@
+import uuid
+from app.core.security import create_access_token, hash_password
+from app.models.user import User
+
+async def make_user(db_session, email="test@example.com") -> User:
+    user = User(username="testuser", email=email, password_hash=hash_password("pw"))
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+async def test_issue_code_returns_code(client, db_session, fake_redis):
+    """정상 요청 → code 필드가 있는 응답 반환"""
+    user = await make_user(db_session)
+    token = create_access_token(str(user.id))
+
+    response = await client.post(
+        "/api/v1/auth/issue-code",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    assert "code" in response.json()
+
+
+async def test_issue_code_stores_user_id_in_redis(client, db_session, fake_redis):
+    """발급된 code로 Redis를 조회하면 user_id가 저장돼 있어야 한다"""
+    user = await make_user(db_session)
+    token = create_access_token(str(user.id))
+
+    response = await client.post(
+        "/api/v1/auth/issue-code",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    code = response.json()["code"]
+    stored = await fake_redis.get(f"auth_code:{code}")
+    assert stored == str(user.id)
+
+
+async def test_issue_code_without_token_rejected(client):
+    """인증 헤더 없음 → 4xx 반환"""
+    response = await client.post("/api/v1/auth/issue-code")
+    assert response.status_code in (401, 403)
+
+
+async def test_issue_code_with_invalid_token_returns_401(client):
+    """유효하지 않은 토큰 → 401"""
+    response = await client.post(
+        "/api/v1/auth/issue-code",
+        headers={"Authorization": "Bearer invalid.token.value"},
+    )
+    assert response.status_code == 401
+
+
+async def test_issue_code_with_unknown_user_returns_401(client):
+    """DB에 없는 유저의 토큰 → 401"""
+    token = create_access_token(str(uuid.uuid4()))
+    response = await client.post(
+        "/api/v1/auth/issue-code",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 401

--- a/server/tests/api/test_objects.py
+++ b/server/tests/api/test_objects.py
@@ -1,0 +1,85 @@
+import pytest
+from unittest.mock import MagicMock
+
+from app.core.security import create_access_token, hash_password
+from app.models.user import User
+from app.infra.s3 import get_s3_client
+from app.main import app
+
+
+async def make_user(db_session, email="test@example.com") -> User:
+    user = User(username="testuser", email=email, password_hash=hash_password("pw"))
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def fake_s3():
+    s3 = MagicMock()
+    s3.generate_presigned_url.return_value = "https://fake-s3.example.com/upload?sig=abc"
+    app.dependency_overrides[get_s3_client] = lambda: s3
+    yield s3
+    app.dependency_overrides.pop(get_s3_client, None)
+
+
+async def test_presigned_url_without_token_rejected(client):
+    """인증 헤더 없이 요청 → 401/403"""
+    response = await client.post(
+        "/api/v1/objects/presigned-upload-url",
+        json={"object_name": "test.mp4"},
+    )
+    assert response.status_code in (401, 403)
+
+
+async def test_presigned_url_with_invalid_token_returns_401(client):
+    """유효하지 않은 토큰 → 401"""
+    response = await client.post(
+        "/api/v1/objects/presigned-upload-url",
+        headers={"Authorization": "Bearer invalid.token.value"},
+        json={"object_name": "test.mp4"},
+    )
+    assert response.status_code == 401
+
+
+async def test_presigned_url_with_unknown_user_returns_401(client):
+    """DB에 없는 유저의 토큰 → 401"""
+    import uuid
+    token = create_access_token(str(uuid.uuid4()))
+    response = await client.post(
+        "/api/v1/objects/presigned-upload-url",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"object_name": "test.mp4"},
+    )
+    assert response.status_code == 401
+
+
+async def test_presigned_url_returns_url_with_valid_auth(client, db_session, fake_s3):
+    """유효한 토큰 + S3 mock → 200과 url 반환"""
+    user = await make_user(db_session)
+    token = create_access_token(str(user.id))
+
+    response = await client.post(
+        "/api/v1/objects/presigned-upload-url",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"object_name": "test.mp4"},
+    )
+
+    assert response.status_code == 200
+    assert "url" in response.json()
+
+
+async def test_presigned_url_calls_s3_with_correct_key(client, db_session, fake_s3):
+    """S3 generate_presigned_url가 요청한 object_name으로 호출되는지 검증"""
+    user = await make_user(db_session)
+    token = create_access_token(str(user.id))
+
+    await client.post(
+        "/api/v1/objects/presigned-upload-url",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"object_name": "episode_001.mp4"},
+    )
+
+    call_kwargs = fake_s3.generate_presigned_url.call_args
+    assert call_kwargs[1]["Params"]["Key"] == "episode_001.mp4"

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -1,0 +1,99 @@
+import os
+import asyncio
+import asyncpg
+
+# app 모듈 import 전에 환경변수 설정
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-pytest")
+os.environ.setdefault("REDIS_URL", "redis://fake")
+
+_BASE_URL = os.environ.get(
+    "DATABASE_URL",
+    "postgresql+asyncpg://robot_studio:robot_studio@postgres:5432/robot_studio",
+)
+
+_TEST_DB_NAME = "robot_studio_test"
+TEST_DATABASE_URL = _BASE_URL.rsplit("/", 1)[0] + f"/{_TEST_DB_NAME}"
+_ASYNCPG_ADMIN_URL = (
+    _BASE_URL.replace("postgresql+asyncpg://", "postgresql://").rsplit("/", 1)[0]
+    + "/postgres"
+)
+
+
+async def _ensure_test_db():
+    """robot_studio_test DB가 없으면 생성"""
+    conn = await asyncpg.connect(_ASYNCPG_ADMIN_URL)
+    exists = await conn.fetchval(
+        "SELECT 1 FROM pg_database WHERE datname=$1", _TEST_DB_NAME
+    )
+    if not exists:
+        await conn.execute(f'CREATE DATABASE "{_TEST_DB_NAME}"')
+    await conn.close()
+
+
+asyncio.run(_ensure_test_db())
+
+os.environ["DATABASE_URL"] = TEST_DATABASE_URL
+
+import pytest_asyncio
+import fakeredis.aioredis
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
+from sqlalchemy.pool import NullPool
+
+# database 모듈을 먼저 import한 뒤 엔진을 교체
+# NullPool: 각 작업마다 독립적인 연결 사용 → fixture 간 연결 충돌 방지
+import app.infra.database as db_module
+from app.infra.database import Base
+
+_test_engine = create_async_engine(TEST_DATABASE_URL, poolclass=NullPool)
+_test_session_factory = async_sessionmaker(
+    _test_engine, class_=AsyncSession, expire_on_commit=False
+)
+
+db_module.engine = _test_engine
+db_module.async_session = _test_session_factory
+
+# 엔진 교체 후 app import → main.py의 lifespan이 test 엔진 사용
+from app.main import app
+from app.infra.database import get_db
+from app.core.redis import get_redis
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def setup_db():
+    """각 테스트 전 테이블 생성, 후 제거"""
+    async with _test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with _test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    async with _test_session_factory() as session:
+        yield session
+
+
+@pytest_asyncio.fixture
+async def fake_redis():
+    r = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    yield r
+    await r.aclose()
+
+
+@pytest_asyncio.fixture
+async def client(db_session, fake_redis):
+    async def override_get_db():
+        yield db_session
+
+    async def override_get_redis():
+        return fake_redis
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_redis] = override_get_redis
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        yield ac
+
+    app.dependency_overrides.clear()

--- a/server/tests/services/test_auth_service.py
+++ b/server/tests/services/test_auth_service.py
@@ -51,3 +51,52 @@ async def test_issue_code_each_call_returns_unique_code(db_session, fake_redis):
     code2 = await service.issue_code(str(user.id), fake_redis)
 
     assert code1 != code2
+
+async def test_exchange_code_returns_token_pair(db_session, fake_redis):
+    """유효한 code → (access_token, refresh_token) 튜플 반환"""
+    user = await make_user(db_session)
+    service = AuthService(db_session)
+    code = await service.issue_code(str(user.id), fake_redis)
+
+    access_token, refresh_token = await service.exchange_code(code, fake_redis)
+
+    assert isinstance(access_token, str) and len(access_token) > 0
+    assert isinstance(refresh_token, str) and len(refresh_token) > 0
+
+
+async def test_exchange_code_deletes_code_from_redis(db_session, fake_redis):
+    """교환 후 Redis에서 code가 삭제되는지 검증"""
+    user = await make_user(db_session)
+    service = AuthService(db_session)
+    code = await service.issue_code(str(user.id), fake_redis)
+
+    await service.exchange_code(code, fake_redis)
+
+    remaining = await fake_redis.get(f"auth_code:{code}")
+    assert remaining is None
+
+
+async def test_exchange_code_is_one_time_use(db_session, fake_redis):
+    """같은 code를 두 번 사용하면 두 번째 호출에서 ValueError"""
+    user = await make_user(db_session)
+    service = AuthService(db_session)
+    code = await service.issue_code(str(user.id), fake_redis)
+
+    await service.exchange_code(code, fake_redis)
+
+    try:
+        await service.exchange_code(code, fake_redis)
+        assert False, "두 번째 exchange_code는 ValueError를 발생시켜야 한다"
+    except ValueError:
+        pass
+
+
+async def test_exchange_code_with_invalid_code_raises(db_session, fake_redis):
+    """존재하지 않는 code → ValueError"""
+    service = AuthService(db_session)
+
+    try:
+        await service.exchange_code("nonexistent_code", fake_redis)
+        assert False, "ValueError가 발생해야 한다"
+    except ValueError:
+        pass

--- a/server/tests/services/test_auth_service.py
+++ b/server/tests/services/test_auth_service.py
@@ -1,0 +1,53 @@
+from app.core.security import hash_password
+from app.models.user import User
+from app.services.auth_service import AuthService
+
+async def make_user(db_session, email="test@example.com") -> User:
+    user = User(username="testuser", email=email, password_hash=hash_password("pw"))
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+async def test_issue_code_returns_nonempty_string(db_session, fake_redis):
+    """code가 빈 문자열이 아닌 값으로 반환되는지 검증"""
+    user = await make_user(db_session)
+    service = AuthService(db_session)
+
+    code = await service.issue_code(str(user.id), fake_redis)
+
+    assert isinstance(code, str)
+    assert len(code) > 0
+
+
+async def test_issue_code_stores_user_id_in_redis(db_session, fake_redis):
+    """Redis에 auth_code:{code} 키로 user_id가 저장되는지 검증"""
+    user = await make_user(db_session)
+    service = AuthService(db_session)
+
+    code = await service.issue_code(str(user.id), fake_redis)
+
+    stored = await fake_redis.get(f"auth_code:{code}")
+    assert stored == str(user.id)
+
+
+async def test_issue_code_expires_in_30_seconds(db_session, fake_redis):
+    """Redis TTL이 30초로 설정되는지 검증"""
+    user = await make_user(db_session)
+    service = AuthService(db_session)
+
+    code = await service.issue_code(str(user.id), fake_redis)
+
+    ttl = await fake_redis.ttl(f"auth_code:{code}")
+    assert 0 < ttl <= 30
+
+
+async def test_issue_code_each_call_returns_unique_code(db_session, fake_redis):
+    """호출할 때마다 다른 code가 발급되는지 검증"""
+    user = await make_user(db_session)
+    service = AuthService(db_session)
+
+    code1 = await service.issue_code(str(user.id), fake_redis)
+    code2 = await service.issue_code(str(user.id), fake_redis)
+
+    assert code1 != code2

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import Login from "./pages/Login";
 import Signup from "./pages/Signup";
+import AuthCallback from "./pages/AuthCallback";
 
 function App() {
   return (
@@ -9,6 +10,7 @@ function App() {
         <Route path="/login" element={<Login />} />
         <Route path="/signup" element={<Signup />} />
         <Route path="*" element={<Navigate to="/login" replace />} />
+        <Route path="/auth/callback" element={<AuthCallback />} />
       </Routes>
     </BrowserRouter>
   );

--- a/web/src/pages/AuthCallback.css
+++ b/web/src/pages/AuthCallback.css
@@ -1,0 +1,25 @@
+.callback-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0;
+}
+
+.callback-card h1 {
+  margin: 0 0 8px;
+}
+
+.callback-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid #e5e5e5;
+  border-top-color: #111;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  margin-bottom: 24px;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}

--- a/web/src/pages/AuthCallback.tsx
+++ b/web/src/pages/AuthCallback.tsx
@@ -1,0 +1,14 @@
+import "./Auth.css";
+import "./AuthCallback.css";
+
+export default function AuthCallback() {
+  return (
+    <div className="auth-container">
+      <div className="auth-card callback-card">
+        <div className="callback-spinner" />
+        <h1>로그인 중</h1>
+        <p className="subtitle">잠시만 기다려 주세요...</p>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -15,7 +15,17 @@ export default function Login() {
       const { access_token, refresh_token } = await login(email, password);
       localStorage.setItem("access_token", access_token);
       localStorage.setItem("refresh_token", refresh_token);
-      navigate("/");
+      const params = new URLSearchParams(window.location.search);
+      if (params.get("from") === "robot") {
+        const res = await fetch("/api/v1/auth/issue-code", {
+          method: "POST",
+          headers: { Authorization: `Bearer ${access_token}` },
+        });
+        const { code } = await res.json();
+        navigate(`/auth/callback?code=${code}`);
+      } else {
+        navigate("/");
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : "로그인에 실패했습니다");
     }


### PR DESCRIPTION
## Summary (한 줄 요약)
- QWebEngineView로 기존 웹 로그인 페이지를 임베딩하고, 1회용 단기 코드(Authorization Code) 교환 방식으로 로봇 UI에 인증 흐름 구현

## Background / Why (배경)
- 로봇 UI는 별도 로그인 폼 없이 바로 메인 화면으로 진입하는 구조였음 — 인증 없이 S3 presigned URL 발급이 가능한 상태
- JWT 토큰을 URL에 직접 담으면 ALB/Nginx 액세스 로그, CloudWatch에 토큰이 평문으로 기록되어 로그 접근 권한자가 탈취 가능 — 코드 교환 방식으로 이 문제를 원천 차단
- 코드는 1회용 & 30초 만료로 탈취되더라도 이미 소비된 경우 무효 처리

## What Changed (변경 내용)

**추가 — Robot**
- `LoginWebView` 위젯 — `QWebEngineView`로 `http://localhost:3000/login?from=robot` 로드, `/auth/callback` URL 감지 시 `login_success` 시그널로 code 전달
- `MainWindow` — `QStackedWidget`으로 로그인(index 0) / 메인(index 1) 화면 전환, `login_success` 수신 시 `exchange_code` 호출 후 토큰 저장 및 메인 화면으로 전환
- `ApiClient.exchange_code()` — 코드를 서버에 제출하고 토큰 수신, 401 시 `ValueError` 발생
- `ApiClient._auth_headers()` / `set_token()` — presigned URL 요청에 Authorization 헤더 자동 포함

**추가 — Server API**
- `POST /api/v1/auth/issue-code` — Bearer 토큰으로 인증된 사용자에게 30초 유효 1회용 코드 발급 (Redis SETEX)
- `POST /api/v1/auth/token-exchange` — 코드를 제출하면 access/refresh token 반환, Redis GETDEL로 원자적 1회용 보장
- `get_current_user` FastAPI 의존성 — HTTPBearer로 JWT 검증 후 DB에서 유저 조회
- `GET /auth/callback` 웹 라우트 — React Router에 추가, `from=robot` 로그인 성공 시 `navigate(/auth/callback?code=...)`로 리다이렉트

**추가 — 인프라 & 테스트**
- Redis 서비스 — `docker-compose.yml`에 `redis:7-alpine` 추가, FastAPI에 `REDIS_URL` 환경변수 연결
- pytest 환경 — `robot_studio_test` DB, `NullPool`, `fakeredis` 기반 서버 테스트 인프라 구성
- `colcon test` 환경 — robot_ui 패키지에 `test/test_api_client.py` 추가, `setup.cfg`에 `asyncio_mode = auto` 설정

**수정**
- `POST /api/v1/objects/presigned-upload-url` — `get_current_user` 의존성 추가로 인증 보호
- `pydantic Settings` — `extra = "ignore"` 추가로 `.env`의 불필요한 필드 검증 오류 방지
- `docker-compose.yml` — `server/tests/`, `pytest.ini` 볼륨 마운트 추가
- Robot `Dockerfile` — `PySide6-WebEngine` 의존성 및 `libxkbfile1` 등 QtWebEngine 시스템 라이브러리 설치, `QTWEBENGINE_CHROMIUM_FLAGS=--no-sandbox` 설정

## Design / Considerations (설계 & 고민한 점)
- **코드 교환 방식 선택**: JWT를 URL에 담으면 서버 로그에 평문 노출 — 30초·1회용 코드를 중간 매개로 써서 토큰 유출 경로를 제거
- **Redis GETDEL 처리**: 조회와 삭제를 한 번에 수행해 동시 요청 중 하나만 성공하도록 보장 — 코드 재사용 공격 방어
- **`get_current_user`를 서비스가 아닌 라우터 의존성으로 구현**: 인증 로직은 비즈니스 로직과 분리하는 FastAPI 표준 패턴 적용
- **테스트 DB 분리**: `robot_studio_test` 별도 DB + `NullPool`로 fixture 간 연결 충돌 방지, `fakeredis`로 Redis 의존성 제거

## How to Test (테스트 방법)

**자동화 테스트**
1. 서버 테스트: `docker compose run --rm fastapi python -m pytest -v`
2. 로봇 테스트: `docker compose run --rm robot bash -c "source /opt/ros/humble/setup.bash && colcon test --packages-select robot_ui && colcon test-result --verbose"`

**E2E 수동 검증**
1. `docker compose up --build`로 전체 서비스 기동
2. 로봇 UI 실행 → 로그인 화면(웹 임베디드)이 첫 화면으로 표시되는지 확인
3. `http://localhost:3000/login?from=robot` 접속 → 로그인 성공 시 URL이 `/auth/callback?code=...`로 변경되고 URL에 토큰 없음 확인
4. 로봇 UI에서 코드 교환 후 메인 화면으로 전환 확인
5. 동일 코드 재사용 → 401 반환 확인 (1회용 검증)
6. 인증 없이 `POST /api/v1/objects/presigned-upload-url` → 401/403 반환 확인

## Impact / Risk (영향도 & 리스크)
- `POST /api/v1/objects/presigned-upload-url`에 인증이 추가됨 — 기존에 이 엔드포인트를 토큰 없이 호출하는 클라이언트가 있으면 401 응답 받음
- 로봇 UI 최초 진입 화면이 메인 → 로그인으로 변경됨