### PR TITLE
[Feature/#8]  LeRobot 데이터 수집 파이프라인 구현

### DIFF
--- a/robot/Dockerfile
+++ b/robot/Dockerfile
@@ -41,6 +41,11 @@ RUN apt-get update && apt-get install -y \
     libasound2 \
     && rm -rf /var/lib/apt/lists/*
 
+# ffmpeg 설치 (OpenCV에서 필요)
+RUN apt-get update && apt-get install -y \
+    ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
 # 한글 폰트 설치
 RUN apt-get update && apt-get install -y \
     fonts-nanum \

--- a/robot/requirements.txt
+++ b/robot/requirements.txt
@@ -12,3 +12,5 @@ fastapi
 pydantic
 st3215
 pytest-asyncio>=0.23.0
+pyarrow>=14.0.0
+pandas>=2.0.0

--- a/robot/requirements.txt
+++ b/robot/requirements.txt
@@ -14,3 +14,4 @@ st3215
 pytest-asyncio>=0.23.0
 pyarrow>=14.0.0
 pandas>=2.0.0
+pytest>=7.0.0

--- a/robot/src/robot_sensors/robot_sensors/camera_node.py
+++ b/robot/src/robot_sensors/robot_sensors/camera_node.py
@@ -19,6 +19,9 @@ class CameraNode(Node):
         self.publisher = self.create_publisher(Image, topic_name, 10)
         self.bridge = CvBridge()
 
+        self._retry_interval = 2.0  # 카메라 재연결 시도 간격 (초)
+        self._last_retry_time = 0.0
+
         self.timer = self.create_timer(0.033, self.timer_callback) # 30 FPS
 
     def _open_camera(self):
@@ -29,8 +32,13 @@ class CameraNode(Node):
 
     def timer_callback(self):
         if self.cap is None or not self.cap.isOpened():
-            if self._open_camera():
-                self.get_logger().info(f'Camera {self.camera_id} opened successfully')
+            now = self.get_clock().now().nanoseconds / 1e9
+            if now - self._last_retry_time >= self._retry_interval:
+                self._last_retry_time = now
+                if self._open_camera():
+                    self.get_logger().info(f'Camera {self.camera_id} reopened successfully')
+                else:
+                    self.get_logger().warn(f'Camera {self.camera_id} not available, retrying in {self._retry_interval}s')
             return
 
         ret, frame = self.cap.read()
@@ -38,9 +46,10 @@ class CameraNode(Node):
             msg = self.bridge.cv2_to_imgmsg(frame, encoding='bgr8') # OpenCV 기본 색상 형식 사용
             self.publisher.publish(msg)
         else:
-            self.get_logger().error('Failed to capture image from camera')
+            self.get_logger().warn(f'Camera {self.camera_id} read failed, will retry in {self._retry_interval}s')
             self.cap.release()
             self.cap = None
+            self._last_retry_time = self.get_clock().now().nanoseconds / 1e9
 
 def main(args=None):
     rclpy.init(args=args)

--- a/robot/src/robot_sensors/robot_sensors/camera_node.py
+++ b/robot/src/robot_sensors/robot_sensors/camera_node.py
@@ -19,7 +19,7 @@ class CameraNode(Node):
         self.publisher = self.create_publisher(Image, topic_name, 10)
         self.bridge = CvBridge()
 
-        self.timer = self.create_timer(0.04, self.timer_callback) # 25 FPS
+        self.timer = self.create_timer(0.033, self.timer_callback) # 30 FPS
 
     def _open_camera(self):
         if self.cap is not None:

--- a/robot/src/robot_ui/robot_ui/services/__init__.py
+++ b/robot/src/robot_ui/robot_ui/services/__init__.py
@@ -1,4 +1,6 @@
 from .upload_service import UploadService
-from .recording_service import RecordingService
+from .recording_service import RecordingService, MultiCameraRecordingService
+from .parquet_service import ParquetWriter
+from .metadata_service import MetadataService
 
-__all__ = ['UploadService', 'RecordingService']
+__all__ = ['UploadService', 'RecordingService', 'MultiCameraRecordingService', 'ParquetWriter', 'MetadataService']

--- a/robot/src/robot_ui/robot_ui/services/metadata_service.py
+++ b/robot/src/robot_ui/robot_ui/services/metadata_service.py
@@ -1,0 +1,92 @@
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+from .parquet_service import JOINT_NAMES
+
+INFO_TEMPLATE = {
+    "codebase_version": "v2.0",
+    "robot_type": "so100",
+    "fps": 30,
+    "features": {
+        "observation.state": {"dtype": "float32", "shape": [6], "names": JOINT_NAMES},
+        "action":            {"dtype": "float32", "shape": [6], "names": JOINT_NAMES},
+    },
+    "total_episodes": 0,
+    "total_frames": 0,
+    "total_successes": 0,
+    "chunks_size": 1000,
+    "splits": {"train": "0:0"},
+}
+
+
+def _atomic_write_json(path: Path, data: dict):
+    """임시 파일에 쓴 후 rename — POSIX atomic 보장"""
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False))
+    os.replace(tmp, path)
+
+
+class MetadataService:
+    def __init__(self):
+        self._meta_dir: Path = None
+        self._info: dict = {}
+
+    def load_or_init(self, meta_dir: Path, camera_roles: dict, fps: int = 30) -> int:
+        """
+        세션 시작 시 호출. info.json 없으면 생성.
+        반환: total_frames (ParquetWriter global_frame_offset용)
+        """
+        self._meta_dir = meta_dir
+        meta_dir.mkdir(parents=True, exist_ok=True)
+
+        info_path = meta_dir / "info.json"
+        if info_path.exists():
+            self._info = json.loads(info_path.read_text())
+        else:
+            self._info = dict(INFO_TEMPLATE)
+            self._info["fps"] = fps
+            # 카메라 역할별 video feature 추가
+            for role in camera_roles:
+                key = f"observation.images.{role}"
+                self._info["features"][key] = {
+                    "dtype": "video", "shape": [480, 640, 3],
+                    "names": ["height", "width", "channels"]
+                }
+            _atomic_write_json(info_path, self._info)
+
+        return self._info.get("total_frames", 0)
+
+    def append_episode(
+        self,
+        episode_index: int,
+        length: int,
+        success: bool,
+        language_instruction: str,
+        chunk_index: int,
+    ):
+        """에피소드 완료 시 episodes.jsonl에 1줄 append + info.json 업데이트"""
+        record = {
+            "episode_index":        episode_index,
+            "length":               length,
+            "success":              success,
+            "language_instruction": language_instruction,
+            "chunk_index":          chunk_index,
+            "timestamp":            datetime.utcnow().isoformat(),
+        }
+        jsonl_path = self._meta_dir / "episodes.jsonl"
+        with jsonl_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+        self._info["total_episodes"] += 1
+        self._info["total_frames"]   += length
+        if success:
+            self._info["total_successes"] += 1
+        _atomic_write_json(self._meta_dir / "info.json", self._info)
+
+    def finalize(self):
+        """전체 수집 완료 시 splits 업데이트"""
+        n = self._info["total_episodes"]
+        self._info["splits"] = {"train": f"0:{n}"}
+        _atomic_write_json(self._meta_dir / "info.json", self._info)

--- a/robot/src/robot_ui/robot_ui/services/parquet_service.py
+++ b/robot/src/robot_ui/robot_ui/services/parquet_service.py
@@ -1,0 +1,61 @@
+import pyarrow as pa
+import pyarrow.parquet as pq
+from pathlib import Path
+
+JOINT_NAMES = ['shoulder_pan', 'shoulder_lift', 'elbow_flex', 'wrist_flex', 'wrist_roll', 'gripper']
+
+SCHEMA = pa.schema([
+    ("frame_index",          pa.int64()),
+    ("episode_index",        pa.int64()),
+    ("timestamp",            pa.float32()),
+    ("index",                pa.int64()),           # 세션 전체 절대 프레임 번호
+    ("observation.state",    pa.list_(pa.float32())),  # follower 위치
+    ("action",               pa.list_(pa.float32())),  # leader 위치
+    ("action_is_pad",        pa.bool_()),
+    ("language_instruction", pa.string()),
+    ("next.done",            pa.bool_()),
+    ("next.reward",          pa.float32()),
+    ("next.success",         pa.bool_()),
+])
+
+
+class ParquetWriter:
+    def __init__(self, global_frame_offset: int = 0):
+        """
+        global_frame_offset: 세션 재시작 시 이어받을 info.json의 total_frames
+        """
+        self._offset = global_frame_offset
+
+    def write(
+        self,
+        output_path: Path,
+        episode_index: int,
+        joint_records: list[dict],   # [{"action": [6], "obs_state": [6]}, ...]
+        frame_timestamps: list[float],
+        language_instruction: str,
+        success: bool,
+    ):
+        n = min(len(joint_records), len(frame_timestamps))
+
+        col = {
+            "frame_index":          list(range(n)),
+            "episode_index":        [episode_index] * n,
+            "timestamp":            [float(t) for t in frame_timestamps[:n]],
+            "index":                [self._offset + i for i in range(n)],
+            "observation.state":    [rec["obs_state"] for rec in joint_records[:n]],
+            "action":               [rec["action"]    for rec in joint_records[:n]],
+            "action_is_pad":        [False] * n,
+            "language_instruction": [language_instruction] * n,
+            "next.done":            [i == n - 1 for i in range(n)],
+            "next.reward":          [1.0 if (success and i == n - 1) else 0.0 for i in range(n)],
+            "next.success":         [success if i == n - 1 else False for i in range(n)],
+        }
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        table = pa.table(col, schema=SCHEMA)
+        pq.write_table(table, output_path)
+
+        self._offset += n
+
+    def get_global_offset(self) -> int:
+        return self._offset

--- a/robot/src/robot_ui/robot_ui/services/recording_service.py
+++ b/robot/src/robot_ui/robot_ui/services/recording_service.py
@@ -177,6 +177,11 @@ class MultiCameraRecordingService:
         self._frame_dirs: dict[str, Path] = {}
         self._frame_timestamps: dict[str, list] = {}
         self._frame_counters: dict[str, int] = {}
+        self._display_callback: Optional[callable] = None  # (role, cv_image) → None
+
+    def set_display_callback(self, cb):
+        """프레임 수신 시 UI에 표시하기 위한 콜백 설정. cb(role, cv_image)"""
+        self._display_callback = cb
 
     def start_episode(self, session_dir: Path, episode_index: int, camera_roles: dict):
         """에피소드 시작 시 role별 PNG 저장 디렉토리 초기화"""
@@ -200,6 +205,8 @@ class MultiCameraRecordingService:
             cv2.imwrite(str(self._frame_dirs[role] / f"{idx:06d}.png"), cv_image)
             self._frame_timestamps[role].append(time.time())
             self._frame_counters[role] += 1
+            if self._display_callback:
+                self._display_callback(role, cv_image.copy())
         except Exception as e:
             multi_camera_logger.error(f"[{role}] frame save failed: {e}")
 
@@ -210,19 +217,37 @@ class MultiCameraRecordingService:
         on_status: Optional[Callable[[str], None]] = None,
         on_progress: Optional[Callable[[int], None]] = None,
         ask_result: Optional[Callable[[int], bool]] = None,
+        on_countdown: Optional[Callable] = None,
     ):
         queue = asyncio.Queue()
         await asyncio.gather(
-            self._collect_episodes(settings, session_dir, queue, on_status, on_progress, ask_result),
+            self._collect_episodes(settings, session_dir, queue, on_status, on_progress, ask_result, on_countdown),
             self._process_episodes(settings, session_dir, queue, on_status, on_progress),
         )
+
+    async def _tick_countdown(
+        self,
+        total: float,
+        phase: str,
+        episode_idx: int,
+        total_episodes: int,
+        on_countdown,
+    ):
+        """0.1초 간격으로 카운트다운 콜백을 호출하며 total초를 기다린다."""
+        elapsed = 0.0
+        interval = 0.1
+        while elapsed < total:
+            remaining = max(0.0, total - elapsed)
+            on_countdown(phase, remaining, total, episode_idx, total_episodes)
+            await asyncio.sleep(interval)
+            elapsed += interval
 
     async def _collect_episodes(
         self,
         settings: dict,
         session_dir: Path,
         queue: asyncio.Queue,
-        on_status, on_progress, ask_result,
+        on_status, on_progress, ask_result, on_countdown,
     ):
         """수집 루프 (producer): 에피소드 수집 후 episode_data를 queue에 넣는다."""
         episodes     = settings.get('episodes', 1)
@@ -239,7 +264,10 @@ class MultiCameraRecordingService:
             self.start_episode(session_dir, i, camera_roles)
             self.joint_collector.start_episode()
 
-            await asyncio.sleep(data_length)
+            if on_countdown:
+                await self._tick_countdown(data_length, 'recording', i, episodes, on_countdown)
+            else:
+                await asyncio.sleep(data_length)
 
             # 성공/실패 팝업
             success = True
@@ -261,9 +289,10 @@ class MultiCameraRecordingService:
             })
 
             if i < episodes - 1 and term_length > 0:
-                if on_status:
-                    on_status(f"Waiting {term_length}s before next episode...")
-                await asyncio.sleep(term_length)
+                if on_countdown:
+                    await self._tick_countdown(term_length, 'waiting', i, episodes, on_countdown)
+                else:
+                    await asyncio.sleep(term_length)
 
         await queue.put(None)  # sentinel: 워커 종료 신호
 

--- a/robot/src/robot_ui/robot_ui/services/recording_service.py
+++ b/robot/src/robot_ui/robot_ui/services/recording_service.py
@@ -1,5 +1,7 @@
 import asyncio
+import subprocess
 import tempfile
+import time
 import cv2
 from pathlib import Path
 from typing import Callable, Optional
@@ -128,3 +130,211 @@ class RecordingService:
 
         logger.info(f"Saved video: {video_path} ({len(self.collected_frames)} frames)")
         return video_path
+
+
+# ---------------------------------------------------------------------------
+# MultiCameraRecordingService
+# ---------------------------------------------------------------------------
+
+def _check_av1_support() -> bool:
+    result = subprocess.run(["ffmpeg", "-encoders"], capture_output=True, text=True)
+    return "libsvtav1" in result.stdout
+
+
+def _encode_video_sync(frames_dir: Path, output_path: Path, fps: int = 30):
+    """PNG 시퀀스를 AV1(또는 H264) MP4로 인코딩 (동기 — asyncio.to_thread로 호출)"""
+    codec = "libsvtav1" if _check_av1_support() else "libx264"
+    crf   = "50" if codec == "libsvtav1" else "23"
+    extra = ["-preset", "6"] if codec == "libsvtav1" else ["-preset", "fast"]
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run([
+        "ffmpeg", "-y",
+        "-f", "image2", "-framerate", str(fps),
+        "-i", str(frames_dir / "%06d.png"),
+        "-vcodec", codec, "-pix_fmt", "yuv420p",
+        "-crf", crf, *extra,
+        str(output_path),
+    ], check=True, capture_output=True)
+
+
+multi_camera_logger = get_logger('MultiCameraRecordingService')
+
+
+class MultiCameraRecordingService:
+    """
+    camera_roles: dict[str, str]  — {"top": "/camera_0/image_raw", "wrist": "/camera_2/image_raw"}
+    joint_collector: JointStateCollector — 필수 (Optional 아님)
+    """
+
+    def __init__(self, upload_service, joint_collector, metadata_service, parquet_writer):
+        self.upload_service   = upload_service
+        self.joint_collector  = joint_collector
+        self.metadata_service = metadata_service
+        self.parquet_writer   = parquet_writer
+        self.bridge           = CvBridge()
+
+        self._frame_dirs: dict[str, Path] = {}
+        self._frame_timestamps: dict[str, list] = {}
+        self._frame_counters: dict[str, int] = {}
+
+    def start_episode(self, session_dir: Path, episode_index: int, camera_roles: dict):
+        """에피소드 시작 시 role별 PNG 저장 디렉토리 초기화"""
+        self._frame_dirs.clear()
+        self._frame_timestamps.clear()
+        self._frame_counters.clear()
+        for role in camera_roles:
+            png_dir = session_dir / "frames" / f"episode_{episode_index:06d}" / role
+            png_dir.mkdir(parents=True, exist_ok=True)
+            self._frame_dirs[role] = png_dir
+            self._frame_timestamps[role] = []
+            self._frame_counters[role] = 0
+
+    def on_frame_received(self, role: str, msg: Image):
+        """프레임 수신 즉시 PNG로 저장 — 메모리 버퍼 없음"""
+        if role not in self._frame_dirs:
+            return
+        try:
+            cv_image = self.bridge.imgmsg_to_cv2(msg, desired_encoding='bgr8')
+            idx = self._frame_counters[role]
+            cv2.imwrite(str(self._frame_dirs[role] / f"{idx:06d}.png"), cv_image)
+            self._frame_timestamps[role].append(time.time())
+            self._frame_counters[role] += 1
+        except Exception as e:
+            multi_camera_logger.error(f"[{role}] frame save failed: {e}")
+
+    async def run(
+        self,
+        settings: dict,
+        session_dir: Path,
+        on_status: Optional[Callable[[str], None]] = None,
+        on_progress: Optional[Callable[[int], None]] = None,
+        ask_result: Optional[Callable[[int], bool]] = None,
+    ):
+        queue = asyncio.Queue()
+        await asyncio.gather(
+            self._collect_episodes(settings, session_dir, queue, on_status, on_progress, ask_result),
+            self._process_episodes(settings, session_dir, queue, on_status, on_progress),
+        )
+
+    async def _collect_episodes(
+        self,
+        settings: dict,
+        session_dir: Path,
+        queue: asyncio.Queue,
+        on_status, on_progress, ask_result,
+    ):
+        """수집 루프 (producer): 에피소드 수집 후 episode_data를 queue에 넣는다."""
+        episodes     = settings.get('episodes', 1)
+        data_length  = settings.get('data_length', 10.0)
+        term_length  = settings.get('term_length', 1.0)
+        camera_roles = settings['camera_roles']
+        language     = settings.get('language_instruction', '')
+        chunk_index  = 0
+
+        for i in range(episodes):
+            if on_status:
+                on_status(f"Recording episode {i + 1}/{episodes}...")
+
+            self.start_episode(session_dir, i, camera_roles)
+            self.joint_collector.start_episode()
+
+            await asyncio.sleep(data_length)
+
+            # 성공/실패 팝업
+            success = True
+            if ask_result:
+                success = await ask_result(i)
+
+            # align_to_frames는 start_episode() 전에 호출해야 버퍼가 유효함
+            primary_role     = next(iter(camera_roles))
+            frame_timestamps = list(self._frame_timestamps[primary_role])  # 복사
+            joint_records    = self.joint_collector.align_to_frames(frame_timestamps)
+
+            await queue.put({
+                'episode_index':        i,
+                'chunk_index':          chunk_index,
+                'frame_timestamps':     frame_timestamps,
+                'joint_records':        joint_records,
+                'success':              success,
+                'language_instruction': language,
+            })
+
+            if i < episodes - 1 and term_length > 0:
+                if on_status:
+                    on_status(f"Waiting {term_length}s before next episode...")
+                await asyncio.sleep(term_length)
+
+        await queue.put(None)  # sentinel: 워커 종료 신호
+
+    async def _process_episodes(
+        self,
+        settings: dict,
+        session_dir: Path,
+        queue: asyncio.Queue,
+        on_status, on_progress,
+    ):
+        """인코딩+업로드 워커 (consumer): queue에서 하나씩 꺼내 순서대로 처리한다."""
+        dataset_name = settings['dataset_name']
+        camera_roles = settings['camera_roles']
+
+        while True:
+            item = await queue.get()
+            if item is None:
+                break
+
+            i             = item['episode_index']
+            chunk_index   = item['chunk_index']
+            timestamps    = item['frame_timestamps']
+            joint_records = item['joint_records']
+            success       = item['success']
+            language      = item['language_instruction']
+
+            if on_status:
+                on_status(f"Encoding episode {i + 1}...")
+
+            # ffmpeg 인코딩 — asyncio.to_thread로 실행 (subprocess 블로킹 방지)
+            for role in camera_roles:
+                png_dir  = session_dir / "frames" / f"episode_{i:06d}" / role
+                out_path = (session_dir / "videos" / f"chunk-{chunk_index:03d}"
+                            / f"observation.images.{role}" / f"episode_{i:06d}.mp4")
+                await asyncio.to_thread(_encode_video_sync, png_dir, out_path)
+
+            # Parquet 저장
+            parquet_path = (session_dir / "data" / f"chunk-{chunk_index:03d}"
+                            / f"episode_{i:06d}.parquet")
+            self.parquet_writer.write(
+                output_path=parquet_path,
+                episode_index=i,
+                joint_records=joint_records,
+                frame_timestamps=timestamps,
+                language_instruction=language,
+                success=success,
+            )
+
+            # 메타데이터 업데이트
+            self.metadata_service.append_episode(
+                episode_index=i,
+                length=len(timestamps),
+                success=success,
+                language_instruction=language,
+                chunk_index=chunk_index,
+            )
+
+            if on_status:
+                on_status(f"Uploading episode {i + 1}...")
+
+            await self.upload_service.upload_episode(
+                session_dir=session_dir,
+                dataset_name=dataset_name,
+                episode_index=i,
+                chunk_index=chunk_index,
+                camera_roles=list(camera_roles.keys()),
+            )
+
+            if on_progress:
+                on_progress(i)
+
+        # 모든 에피소드 처리 완료 후 메타 업로드
+        self.metadata_service.finalize()
+        await self.upload_service.upload_meta(session_dir, dataset_name)

--- a/robot/src/robot_ui/robot_ui/services/recording_service.py
+++ b/robot/src/robot_ui/robot_ui/services/recording_service.py
@@ -218,10 +218,11 @@ class MultiCameraRecordingService:
         on_progress: Optional[Callable[[int], None]] = None,
         ask_result: Optional[Callable[[int], bool]] = None,
         on_countdown: Optional[Callable] = None,
+        on_collection_done: Optional[Callable[[int], None]] = None,
     ):
         queue = asyncio.Queue()
         await asyncio.gather(
-            self._collect_episodes(settings, session_dir, queue, on_status, on_progress, ask_result, on_countdown),
+            self._collect_episodes(settings, session_dir, queue, on_status, on_progress, ask_result, on_countdown, on_collection_done),
             self._process_episodes(settings, session_dir, queue, on_status, on_progress),
         )
 
@@ -247,7 +248,7 @@ class MultiCameraRecordingService:
         settings: dict,
         session_dir: Path,
         queue: asyncio.Queue,
-        on_status, on_progress, ask_result, on_countdown,
+        on_status, on_progress, ask_result, on_countdown, on_collection_done=None,
     ):
         """수집 루프 (producer): 에피소드 수집 후 episode_data를 queue에 넣는다."""
         episodes     = settings.get('episodes', 1)
@@ -294,6 +295,8 @@ class MultiCameraRecordingService:
                 else:
                     await asyncio.sleep(term_length)
 
+        if on_collection_done:
+            on_collection_done(episodes)
         await queue.put(None)  # sentinel: 워커 종료 신호
 
     async def _process_episodes(

--- a/robot/src/robot_ui/robot_ui/services/recording_service.py
+++ b/robot/src/robot_ui/robot_ui/services/recording_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 import subprocess
 import tempfile
 import time
@@ -136,6 +137,7 @@ class RecordingService:
 # MultiCameraRecordingService
 # ---------------------------------------------------------------------------
 
+@functools.lru_cache(maxsize=None)
 def _check_av1_support() -> bool:
     result = subprocess.run(["ffmpeg", "-encoders"], capture_output=True, text=True)
     return "libsvtav1" in result.stdout

--- a/robot/src/robot_ui/robot_ui/services/upload_service.py
+++ b/robot/src/robot_ui/robot_ui/services/upload_service.py
@@ -18,11 +18,11 @@ class UploadService:
         self,
         file_path: str,
         object_name: str,
-        content_type: str = "video/mp4",
+        content_type: str = "application/octet-stream",
     ) -> bool:
         for attempt in range(self.max_retries):
             try:
-                presigned_url = await self.api_client.get_presigned_url(object_name)
+                presigned_url = await self.api_client.get_presigned_url(object_name, content_type)
                 await self.api_client.upload_to_s3(presigned_url, file_path, content_type)
                 return True
 

--- a/robot/src/robot_ui/robot_ui/services/upload_service.py
+++ b/robot/src/robot_ui/robot_ui/services/upload_service.py
@@ -1,4 +1,5 @@
 import asyncio
+from pathlib import Path
 from rclpy.logging import get_logger
 
 from ..utils.api_client import ApiClient
@@ -13,11 +14,16 @@ class UploadService:
         self.api_client = api_client
         self.max_retries = max_retries
 
-    async def upload_with_retry(self, video_path: str, object_name: str) -> bool:
+    async def upload_with_retry(
+        self,
+        file_path: str,
+        object_name: str,
+        content_type: str = "video/mp4",
+    ) -> bool:
         for attempt in range(self.max_retries):
             try:
                 presigned_url = await self.api_client.get_presigned_url(object_name)
-                await self._upload_video(video_path, presigned_url)
+                await self.api_client.upload_to_s3(presigned_url, file_path, content_type)
                 return True
 
             except Exception as e:
@@ -33,7 +39,33 @@ class UploadService:
         logger.error(f"Upload failed after {self.max_retries} attempts: '{object_name}'")
         return False
 
-    async def _upload_video(self, video_path: str, presigned_url: str):
-        """Presigned URL로 비디오 파일 업로드"""
-        await self.api_client.upload_to_s3(presigned_url, video_path)
-        logger.info(f"Upload successful: {presigned_url[:50]}...")
+    async def upload_episode(
+        self,
+        session_dir: Path,
+        dataset_name: str,
+        episode_index: int,
+        chunk_index: int,
+        camera_roles: list[str],
+    ) -> bool:
+        """비디오(role별) + parquet 파일을 병렬 업로드"""
+        chunk = f"chunk-{chunk_index:03d}"
+        ep    = f"episode_{episode_index:06d}"
+
+        tasks = []
+        for role in camera_roles:
+            local  = session_dir / "videos" / chunk / f"observation.images.{role}" / f"{ep}.mp4"
+            s3_key = f"{dataset_name}/videos/{chunk}/observation.images.{role}/{ep}.mp4"
+            tasks.append(self.upload_with_retry(str(local), s3_key, "video/mp4"))
+
+        parquet_local = session_dir / "data" / chunk / f"{ep}.parquet"
+        parquet_s3    = f"{dataset_name}/data/{chunk}/{ep}.parquet"
+        tasks.append(self.upload_with_retry(str(parquet_local), parquet_s3, "application/octet-stream"))
+
+        results = await asyncio.gather(*tasks)
+        return all(results)
+
+    async def upload_meta(self, session_dir: Path, dataset_name: str):
+        """meta/ 디렉토리 전체 업로드"""
+        for meta_file in (session_dir / "meta").iterdir():
+            s3_key = f"{dataset_name}/meta/{meta_file.name}"
+            await self.upload_with_retry(str(meta_file), s3_key, "application/json")

--- a/robot/src/robot_ui/robot_ui/utils/api_client.py
+++ b/robot/src/robot_ui/robot_ui/utils/api_client.py
@@ -72,14 +72,19 @@ class ApiClient:
                 data = await response.json()
                 return data["url"]
 
-    async def upload_to_s3(self, presigned_url: str, video_path: str):
+    async def upload_to_s3(
+        self,
+        presigned_url: str,
+        file_path: str,
+        content_type: str = "video/mp4",
+    ):
         """Presigned URL로 파일 업로드"""
-        with open(video_path, 'rb') as f:
-            video_data = f.read()
+        with open(file_path, 'rb') as f:
+            data = f.read()
 
         async with self.session.put(
             presigned_url,
-            data=video_data,
-            headers={'Content-Type': 'video/mp4'},
+            data=data,
+            headers={'Content-Type': content_type},
         ) as response:
             response.raise_for_status()

--- a/robot/src/robot_ui/robot_ui/utils/api_client.py
+++ b/robot/src/robot_ui/robot_ui/utils/api_client.py
@@ -56,12 +56,12 @@ class ApiClient:
             response.raise_for_status()
             return await response.json()
 
-    async def get_presigned_url(self, object_name: str) -> str:
+    async def get_presigned_url(self, object_name: str, content_type: str = "application/octet-stream") -> str:
         """단일 presigned URL 요청"""
         for attempt in range(2):
             async with self.session.post(
                 f"{self.base_url}/api/v1/objects/presigned-upload-url",
-                json={"object_name": object_name},
+                json={"object_name": object_name, "content_type": content_type},
                 headers=self._auth_headers(),
                 timeout=aiohttp.ClientTimeout(total=10),
             ) as response:
@@ -76,7 +76,7 @@ class ApiClient:
         self,
         presigned_url: str,
         file_path: str,
-        content_type: str = "video/mp4",
+        content_type: str = "application/octet-stream",
     ):
         """Presigned URL로 파일 업로드"""
         with open(file_path, 'rb') as f:

--- a/robot/src/robot_ui/robot_ui/utils/camera_subscriber.py
+++ b/robot/src/robot_ui/robot_ui/utils/camera_subscriber.py
@@ -1,3 +1,4 @@
+import time
 import numpy as np
 from PySide6.QtCore import Signal, QObject
 
@@ -14,11 +15,14 @@ class ImageSignal(QObject):
 class CameraSubscriberNode(Node):
     """ROS2 카메라 토픽 구독 노드"""
 
+    _STALE_THRESHOLD = 5.0  # 프레임 없으면 연결 끊긴 것으로 간주 (초)
+
     def __init__(self, signal: ImageSignal):
         super().__init__('camera_preview_node')
         self.signal = signal
         self.bridge = CvBridge()
         self.subscriptions_dict = {}
+        self._last_frame_time: dict[str, float] = {}
 
     def subscribe_to_topic(self, topic_name: str):
         if topic_name in self.subscriptions_dict:
@@ -27,6 +31,7 @@ class CameraSubscriberNode(Node):
         def callback(msg: Image):
             try:
                 cv_image = self.bridge.imgmsg_to_cv2(msg, desired_encoding='bgr8')
+                self._last_frame_time[topic_name] = time.monotonic()
                 self.signal.image_received.emit(topic_name, cv_image)
             except Exception as e:
                 self.get_logger().error(f'Failed to convert image: {e}')
@@ -39,14 +44,21 @@ class CameraSubscriberNode(Node):
         if topic_name in self.subscriptions_dict:
             self.destroy_subscription(self.subscriptions_dict[topic_name])
             del self.subscriptions_dict[topic_name]
+        self._last_frame_time.pop(topic_name, None)
 
     def get_available_image_topics(self) -> list[str]:
         topics = self.get_topic_names_and_types()
+        now = time.monotonic()
         image_topics = []
         for name, types in topics:
             if 'sensor_msgs/msg/Image' in types:
                 # 실제 publisher가 있는지 확인
                 publishers = self.get_publishers_info_by_topic(name)
-                if len(publishers) > 0:
-                    image_topics.append(name)
+                if len(publishers) == 0:
+                    continue
+                # 구독 중인데 프레임이 끊겼으면 연결 불량으로 간주
+                last_time = self._last_frame_time.get(name)
+                if last_time is not None and (now - last_time) > self._STALE_THRESHOLD:
+                    continue
+                image_topics.append(name)
         return image_topics

--- a/robot/src/robot_ui/robot_ui/utils/joint_state_collector.py
+++ b/robot/src/robot_ui/robot_ui/utils/joint_state_collector.py
@@ -1,0 +1,62 @@
+import time
+from collections import deque
+import numpy as np
+from sensor_msgs.msg import JointState
+from rclpy.node import Node
+
+JOINT_NAMES = ['shoulder_pan', 'shoulder_lift', 'elbow_flex', 'wrist_flex', 'wrist_roll', 'gripper']
+
+
+class JointStateCollector:
+    """에피소드 단위 관절 데이터 수집 + 프레임 타임스탬프 정렬"""
+
+    def __init__(self, ros_node: Node):
+        self._node = ros_node
+        self._leader_buf: deque = deque()    # (wall_time, positions[6])
+        self._follower_buf: deque = deque()  # (wall_time, positions[6])
+
+        self._sub_leader = ros_node.create_subscription(
+            JointState, '/leader/joint_states', self._on_leader, 10
+        )
+        self._sub_follower = ros_node.create_subscription(
+            JointState, '/follower/joint_states', self._on_follower, 10
+        )
+
+    def start_episode(self):
+        """에피소드 시작 전 버퍼 초기화"""
+        self._leader_buf.clear()
+        self._follower_buf.clear()
+
+    def _on_leader(self, msg: JointState):
+        self._leader_buf.append((time.time(), list(msg.position[:6])))
+
+    def _on_follower(self, msg: JointState):
+        self._follower_buf.append((time.time(), list(msg.position[:6])))
+
+    def align_to_frames(self, frame_timestamps: list[float]) -> list[dict]:
+        """
+        프레임 타임스탬프 목록에 관절 데이터를 nearest-neighbor 정렬.
+        반환: [{"action": [6 floats], "obs_state": [6 floats]}, ...]
+        leader/follower 데이터가 없으면 ValueError 발생.
+        """
+        if not self._leader_buf:
+            raise ValueError("No leader joint data collected. Check /leader/joint_states topic.")
+        if not self._follower_buf:
+            raise ValueError("No follower joint data collected. Check /follower/joint_states topic.")
+
+        leader_times   = np.array([t for t, _ in self._leader_buf])
+        leader_pos     = [p for _, p in self._leader_buf]
+        follower_times = np.array([t for t, _ in self._follower_buf])
+        follower_pos   = [p for _, p in self._follower_buf]
+
+        result = []
+        for ts in frame_timestamps:
+            action    = leader_pos[int(np.argmin(np.abs(leader_times - ts)))]
+            obs_state = follower_pos[int(np.argmin(np.abs(follower_times - ts)))]
+            result.append({"action": action, "obs_state": obs_state})
+
+        return result
+
+    def destroy(self):
+        self._node.destroy_subscription(self._sub_leader)
+        self._node.destroy_subscription(self._sub_follower)

--- a/robot/src/robot_ui/robot_ui/views/main_window.py
+++ b/robot/src/robot_ui/robot_ui/views/main_window.py
@@ -74,6 +74,15 @@ class MainWindow(QMainWindow):
         self.empty_area.setStyleSheet("background-color: #1e1e1e;")
         main_layout.addWidget(self.empty_area, 1)
 
+        # 카메라 토픽 목록 → DatasetSettingPanel 콤보박스 연결
+        self.camera_preview_area.topics_updated.connect(
+            self.dataset_setting_panel.set_available_topics
+        )
+        # 초기화 시 이미 발견된 토픽 즉시 반영
+        self.dataset_setting_panel.set_available_topics(
+            list(self.camera_preview_area.preview_widgets.keys())
+        )
+
         self.stacked_widget.addWidget(main_page)  # index 1
         self.stacked_widget.setCurrentIndex(0)
 
@@ -111,8 +120,6 @@ class MainWindow(QMainWindow):
 
     def _on_camera_selected(self, topic_name: str):
         """카메라 선택 시 Dataset Setting 화면으로 전환"""
-        self.dataset_setting_panel.set_camera(topic_name)
-
         # 모든 영역 숨기고 Dataset Setting 표시
         self.camera_preview_area.setVisible(False)
         self.dataset_setting_panel.setVisible(True)

--- a/robot/src/robot_ui/robot_ui/views/main_window.py
+++ b/robot/src/robot_ui/robot_ui/views/main_window.py
@@ -74,10 +74,8 @@ class MainWindow(QMainWindow):
         self.empty_area.setStyleSheet("background-color: #1e1e1e;")
         main_layout.addWidget(self.empty_area, 1)
 
-        # 카메라 토픽 목록 → DatasetSettingPanel 콤보박스 연결
-        self.camera_preview_area.topics_updated.connect(
-            self.dataset_setting_panel.set_available_topics
-        )
+        # 카메라 토픽 목록 → DatasetSettingPanel 콤보박스 + DataCollectionPanel 그리드 연결
+        self.camera_preview_area.topics_updated.connect(self._on_topics_updated)
         # 초기화 시 이미 발견된 토픽 즉시 반영
         self.dataset_setting_panel.set_available_topics(
             list(self.camera_preview_area.preview_widgets.keys())
@@ -100,6 +98,13 @@ class MainWindow(QMainWindow):
         except Exception as e:
             logger.error(f"Code exchange failed: {e}")
             self.login_webview.reset()
+
+    def _on_topics_updated(self, topics: list):
+        self.dataset_setting_panel.set_available_topics(topics)
+        if self.data_collection_panel.isVisible():
+            self.data_collection_panel.update_camera_roles(
+                self.dataset_setting_panel.get_settings()['camera_roles']
+            )
 
     def _on_menu_selected(self, menu_id: str):
         # 모든 영역 숨기기

--- a/robot/src/robot_ui/robot_ui/widgets/camera_preview.py
+++ b/robot/src/robot_ui/robot_ui/widgets/camera_preview.py
@@ -99,7 +99,8 @@ class CameraPreviewWidget(QFrame):
 class CameraPreviewArea(QWidget):
     """메인 영역의 카메라 프리뷰 그리드"""
 
-    camera_selected = Signal(str)  # topic_name 전달
+    camera_selected = Signal(str)   # topic_name 전달
+    topics_updated  = Signal(list)  # 사용 가능한 topic 목록 전달
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -232,6 +233,7 @@ class CameraPreviewArea(QWidget):
                 self._remove_preview(topic)
 
         self._update_grid_layout()
+        self.topics_updated.emit(list(self.preview_widgets.keys()))
 
     def _add_preview(self, topic_name: str):
         widget = CameraPreviewWidget(topic_name)

--- a/robot/src/robot_ui/robot_ui/widgets/data_collection.py
+++ b/robot/src/robot_ui/robot_ui/widgets/data_collection.py
@@ -422,6 +422,13 @@ class DataCollectionPanel(QWidget):
             lambda msg: self._joint_signal.received.emit(list(msg.position)), 10
         )
 
+    def update_camera_roles(self, camera_roles: dict):
+        """토픽 목록 갱신 시 카메라 그리드만 업데이트 (녹화 중엔 무시)"""
+        if self.is_recording:
+            return
+        self.settings['camera_roles'] = camera_roles
+        self._rebuild_camera_grid(camera_roles)
+
     def set_recording_config(self, settings: dict):
         self.settings = settings
 

--- a/robot/src/robot_ui/robot_ui/widgets/data_collection.py
+++ b/robot/src/robot_ui/robot_ui/widgets/data_collection.py
@@ -115,6 +115,66 @@ class _JointRow(QWidget):
         self._val.setText(str(iv))
 
 
+# ─── 인코딩/업로드 진행 팝업 ──────────────────────────────────────────────────
+
+class _PostProcessDialog(QDialog):
+    """수집 완료 후 인코딩·업로드가 끝날 때까지 사용자 조작을 막는 모달 팝업"""
+
+    def __init__(self, total: int, already_done: int, parent=None):
+        super().__init__(parent)
+        self._total = total
+        self.setWindowTitle("처리 중...")
+        self.setWindowFlags(
+            Qt.WindowType.Dialog |
+            Qt.WindowType.CustomizeWindowHint |
+            Qt.WindowType.WindowTitleHint
+        )
+        self.setWindowModality(Qt.WindowModality.ApplicationModal)
+        self.setFixedSize(400, 140)
+        self.setStyleSheet("background-color: #2d2d2d; color: #ffffff;")
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(24, 20, 24, 20)
+        layout.setSpacing(12)
+
+        self._status_label = QLabel("인코딩 및 업로드 중...")
+        self._status_label.setStyleSheet("color: #cccccc; font-size: 13px;")
+        layout.addWidget(self._status_label)
+
+        self._bar = QProgressBar()
+        self._bar.setRange(0, total)
+        self._bar.setValue(already_done)
+        self._bar.setFixedHeight(12)
+        self._bar.setTextVisible(False)
+        self._bar.setStyleSheet("""
+            QProgressBar { border: none; border-radius: 4px; background-color: #1e1e1e; }
+            QProgressBar::chunk { background-color: #0e639c; border-radius: 4px; }
+        """)
+        layout.addWidget(self._bar)
+
+        self._progress_label = QLabel(f"에피소드 {already_done} / {total} 완료")
+        self._progress_label.setStyleSheet("color: #858585; font-size: 11px;")
+        self._progress_label.setAlignment(Qt.AlignmentFlag.AlignRight)
+        layout.addWidget(self._progress_label)
+
+    def set_status(self, text: str):
+        self._status_label.setText(text)
+
+    def set_progress(self, done: int):
+        self._bar.setValue(done)
+        self._progress_label.setText(f"에피소드 {done} / {self._total} 완료")
+        if done >= self._total:
+            self.accept()
+
+    def closeEvent(self, event):
+        event.ignore()  # 처리 완료 전 닫기 차단
+
+    def keyPressEvent(self, event):
+        if event.key() == Qt.Key.Key_Escape:
+            return  # ESC 차단
+        super().keyPressEvent(event)
+
+
 # ─── 3-2-1 카운트다운 오버레이 ─────────────────────────────────────────────────
 
 class _CountdownOverlay(QWidget):
@@ -197,6 +257,7 @@ class DataCollectionPanel(QWidget):
 
         self._camera_widgets: dict[str, _CameraWidget] = {}
         self._joint_rows: list[_JointRow] = []
+        self._post_dialog: _PostProcessDialog | None = None
 
         self._setup_ui()
         self._countdown_overlay = _CountdownOverlay(self)
@@ -453,6 +514,7 @@ class DataCollectionPanel(QWidget):
             on_progress=self._on_progress,
             ask_result=self._ask_episode_result,
             on_countdown=self._on_countdown,
+            on_collection_done=self._on_collection_done,
         )
 
         for sub in self._frame_subscriptions:
@@ -470,12 +532,23 @@ class DataCollectionPanel(QWidget):
 
     def _on_status(self, text: str):
         self._status_label.setText(text)
+        if self._post_dialog and self._post_dialog.isVisible():
+            self._post_dialog.set_status(text)
 
     def _on_progress(self, episode_idx: int):
         done = episode_idx + 1
         total = self.settings.get('episodes', 1)
         self._progress_bar.setValue(done)
         self._progress_label.setText(f"{done} / {total}")
+        if self._post_dialog and self._post_dialog.isVisible():
+            self._post_dialog.set_progress(done)
+
+    def _on_collection_done(self, total: int):
+        """수집 완료 — 미처리 에피소드가 남아 있으면 진행 팝업 표시"""
+        already_done = self._progress_bar.value()
+        if already_done < total:
+            self._post_dialog = _PostProcessDialog(total, already_done, self)
+            self._post_dialog.show()
 
     def _on_countdown(self, phase: str, remaining: float, total: float, ep_idx: int, total_eps: int):
         """수집/대기 카운트다운 매 0.1s 호출"""

--- a/robot/src/robot_ui/robot_ui/widgets/data_collection.py
+++ b/robot/src/robot_ui/robot_ui/widgets/data_collection.py
@@ -1,10 +1,19 @@
 import asyncio
-from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel, QPushButton, QProgressBar
+from datetime import datetime
+from functools import partial
+from pathlib import Path
+
+from PySide6.QtWidgets import (
+    QWidget, QVBoxLayout, QLabel, QPushButton, QProgressBar,
+    QDialog, QHBoxLayout,
+)
 from PySide6.QtCore import Qt, Signal
 from rclpy.logging import get_logger
 from sensor_msgs.msg import Image
+
 from ..utils import ApiClient
-from ..services import UploadService, RecordingService
+from ..utils.joint_state_collector import JointStateCollector
+from ..services import UploadService, MultiCameraRecordingService, ParquetWriter, MetadataService
 
 logger = get_logger('DataCollection')
 
@@ -19,8 +28,12 @@ class DataCollectionPanel(QWidget):
         self.settings: dict = {}
         self.is_recording = False
         self.ros_node = None
-        self._frame_subscription = None
-        self.recording_service = RecordingService(UploadService(ApiClient()))
+        self.joint_collector = None
+        self.recording_service = None
+        self.session_dir: Path = None
+        self.upload_service = UploadService(ApiClient())
+        self._frame_subscriptions: list = []
+        self.recording_task = None
         self._setup_ui()
 
     def _setup_ui(self):
@@ -28,23 +41,14 @@ class DataCollectionPanel(QWidget):
         layout.setContentsMargins(16, 16, 16, 16)
         layout.setSpacing(16)
 
-        # 헤더
         title = QLabel('Data Collection')
-        title.setStyleSheet("""
-            QLabel {
-                color: #ffffff;
-                font-size: 18px;
-                font-weight: 600;
-            }
-        """)
+        title.setStyleSheet("color: #ffffff; font-size: 18px; font-weight: 600;")
         layout.addWidget(title)
 
-        # 상태 표시
         self.status_label = QLabel('Ready to record')
         self.status_label.setStyleSheet("color: #858585; font-size: 14px;")
         layout.addWidget(self.status_label)
 
-        # 진행률 표시
         self.progress_bar = QProgressBar()
         self.progress_bar.setStyleSheet("""
             QProgressBar {
@@ -64,7 +68,6 @@ class DataCollectionPanel(QWidget):
 
         layout.addStretch()
 
-        # Record 버튼
         self.record_btn = QPushButton('Record')
         self.record_btn.setCursor(Qt.CursorShape.PointingHandCursor)
         self.record_btn.setStyleSheet("""
@@ -77,46 +80,70 @@ class DataCollectionPanel(QWidget):
                 font-size: 16px;
                 font-weight: 600;
             }
-            QPushButton:hover {
-                background-color: #e53935;
-            }
-            QPushButton:pressed {
-                background-color: #b71c1c;
-            }
-            QPushButton:disabled {
-                background-color: #5c5c5c;
-            }
+            QPushButton:hover { background-color: #e53935; }
+            QPushButton:pressed { background-color: #b71c1c; }
+            QPushButton:disabled { background-color: #5c5c5c; }
         """)
         self.record_btn.clicked.connect(self._on_record_clicked)
         layout.addWidget(self.record_btn, alignment=Qt.AlignmentFlag.AlignCenter)
 
         layout.addStretch()
 
-    def set_ros_node(self, ros_node):
-        """ROS2 노드 설정"""
-        self.ros_node = ros_node
+    # ------------------------------------------------------------------
+    # 공개 API
+    # ------------------------------------------------------------------
+
+    def set_ros_node(self, node):
+        """ROS2 노드 설정 — JointStateCollector 생성"""
+        self.ros_node = node
+        self.joint_collector = JointStateCollector(node)
 
     def set_recording_config(self, settings: dict):
-        """녹화 설정 저장"""
+        """녹화 설정 저장 — 서비스 초기화"""
         self.settings = settings
+
+        session_id  = datetime.now().strftime("%Y%m%d_%H%M%S")
+        session_dir = Path(f"/tmp/dataset_{session_id}")
+
+        metadata_service = MetadataService()
+        global_offset = metadata_service.load_or_init(
+            session_dir / "meta",
+            camera_roles=settings['camera_roles'],
+            fps=30,
+        )
+        parquet_writer = ParquetWriter(global_frame_offset=global_offset)
+
+        self.recording_service = MultiCameraRecordingService(
+            upload_service=self.upload_service,
+            joint_collector=self.joint_collector,
+            metadata_service=metadata_service,
+            parquet_writer=parquet_writer,
+        )
+        self.session_dir = session_dir
+
         self.status_label.setText(
             f"Ready: {settings['episodes']} episodes, "
             f"{settings['data_length']}s each"
         )
 
+    # ------------------------------------------------------------------
+    # 내부 동작
+    # ------------------------------------------------------------------
+
     def _on_record_clicked(self):
-        """Record 버튼 클릭 시"""
         if not self.is_recording:
-            self.recodign_task = asyncio.create_task(self._start_recording())
+            self.recording_task = asyncio.create_task(self._start_recording())
 
     async def _start_recording(self):
-        """녹화 시작"""
         if not self.ros_node:
             logger.error("ROS2 node not available")
             return
+        if not self.recording_service:
+            logger.error("Recording service not configured. Call set_recording_config() first.")
+            return
 
         episodes = self.settings.get('episodes', 1)
-        topic = self.settings.get('topic', '')
+        camera_roles = self.settings.get('camera_roles', {})
 
         self.is_recording = True
         self.record_btn.setEnabled(False)
@@ -124,22 +151,75 @@ class DataCollectionPanel(QWidget):
         self.progress_bar.setMaximum(episodes)
         self.progress_bar.setValue(0)
 
-        self._frame_subscription = self.ros_node.create_subscription(
-            Image, topic, self.recording_service.on_frame_received, 10
-        )
+        # 카메라 role별 subscription 생성
+        self._frame_subscriptions = []
+        for role, topic in camera_roles.items():
+            sub = self.ros_node.create_subscription(
+                Image, topic,
+                partial(self.recording_service.on_frame_received, role), 10
+            )
+            self._frame_subscriptions.append(sub)
 
         await self.recording_service.run(
-            self.settings,
+            settings=self.settings,
+            session_dir=self.session_dir,
             on_status=self.status_label.setText,
             on_progress=lambda idx: self.progress_bar.setValue(idx + 1),
+            ask_result=self._ask_episode_result,
         )
 
-        if self._frame_subscription:
-            self.ros_node.destroy_subscription(self._frame_subscription)
-            self._frame_subscription = None
+        for sub in self._frame_subscriptions:
+            self.ros_node.destroy_subscription(sub)
+        self._frame_subscriptions = []
 
         self.progress_bar.setValue(episodes)
         self.status_label.setText("Recording complete!")
         self.is_recording = False
         self.record_btn.setEnabled(True)
         self.recording_finished.emit()
+
+    async def _ask_episode_result(self, episode_index: int) -> bool:
+        """에피소드 성공/실패 팝업 — asyncio 루프 블로킹 없이 Future로 대기"""
+        loop   = asyncio.get_event_loop()
+        future = loop.create_future()
+
+        dialog = QDialog(self)
+        dialog.setWindowTitle(f"Episode {episode_index + 1} Result")
+        dialog.setStyleSheet("background-color: #2d2d2d; color: #ffffff;")
+        dialog.setFixedSize(300, 120)
+
+        btn_layout = QHBoxLayout(dialog)
+        btn_layout.setContentsMargins(24, 24, 24, 24)
+        btn_layout.setSpacing(16)
+
+        label = QLabel(f"Episode {episode_index + 1} — Success?")
+        label.setStyleSheet("color: #ffffff; font-size: 14px;")
+
+        success_btn = QPushButton("✓ Success")
+        success_btn.setStyleSheet(
+            "background-color: #388e3c; color: #fff; border: none; "
+            "border-radius: 4px; padding: 8px 20px; font-size: 14px;"
+        )
+        fail_btn = QPushButton("✗ Fail")
+        fail_btn.setStyleSheet(
+            "background-color: #d32f2f; color: #fff; border: none; "
+            "border-radius: 4px; padding: 8px 20px; font-size: 14px;"
+        )
+
+        def _resolve(result: bool):
+            if not future.done():
+                future.set_result(result)
+            dialog.accept()
+
+        success_btn.clicked.connect(lambda: _resolve(True))
+        fail_btn.clicked.connect(lambda: _resolve(False))
+
+        outer = QVBoxLayout()
+        outer.addWidget(label)
+        outer.addLayout(btn_layout)
+        btn_layout.addWidget(success_btn)
+        btn_layout.addWidget(fail_btn)
+        dialog.setLayout(outer)
+        dialog.show()
+
+        return await asyncio.wrap_future(future)

--- a/robot/src/robot_ui/robot_ui/widgets/data_collection.py
+++ b/robot/src/robot_ui/robot_ui/widgets/data_collection.py
@@ -10,7 +10,7 @@ from PySide6.QtWidgets import (
     QDialog, QFrame, QGridLayout, QGroupBox, QScrollArea,
 )
 from PySide6.QtCore import Qt, Signal, QObject
-from PySide6.QtGui import QImage, QPixmap
+from PySide6.QtGui import QImage, QPixmap, QPainter, QFont, QColor
 from rclpy.logging import get_logger
 from sensor_msgs.msg import Image, JointState
 
@@ -115,6 +115,54 @@ class _JointRow(QWidget):
         self._val.setText(str(iv))
 
 
+# ─── 3-2-1 카운트다운 오버레이 ─────────────────────────────────────────────────
+
+class _CountdownOverlay(QWidget):
+    """Record 버튼 클릭 후 3-2-1 카운트다운을 화면 중앙에 표시하는 오버레이"""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._number = 3
+        self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, False)
+        self.setVisible(False)
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+
+        # 반투명 어두운 배경
+        painter.fillRect(self.rect(), QColor(0, 0, 0, 160))
+
+        # 원
+        cx, cy = self.width() // 2, self.height() // 2
+        r = 90
+        painter.setBrush(QColor(211, 47, 47, 230))
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.drawEllipse(cx - r, cy - r, r * 2, r * 2)
+
+        # 숫자
+        font = QFont()
+        font.setPointSize(72)
+        font.setBold(True)
+        painter.setFont(font)
+        painter.setPen(QColor(255, 255, 255))
+        painter.drawText(self.rect(), Qt.AlignmentFlag.AlignCenter, str(self._number))
+
+        painter.end()
+
+    async def run(self):
+        """3 → 2 → 1 순서로 1초씩 표시 후 숨김"""
+        if parent := self.parent():
+            self.setGeometry(parent.rect())
+        self.raise_()
+        self.show()
+        for n in (3, 2, 1):
+            self._number = n
+            self.update()
+            await asyncio.sleep(1.0)
+        self.hide()
+
+
 # ─── 메인 패널 ────────────────────────────────────────────────────────────────
 
 class DataCollectionPanel(QWidget):
@@ -151,6 +199,11 @@ class DataCollectionPanel(QWidget):
         self._joint_rows: list[_JointRow] = []
 
         self._setup_ui()
+        self._countdown_overlay = _CountdownOverlay(self)
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        self._countdown_overlay.setGeometry(self.rect())
 
     # ------------------------------------------------------------------
     # UI 구성
@@ -380,6 +433,9 @@ class DataCollectionPanel(QWidget):
         self._progress_bar.setMaximum(episodes)
         self._progress_bar.setValue(0)
         self._progress_label.setText(f"0 / {episodes}")
+
+        # 3-2-1 카운트다운
+        await self._countdown_overlay.run()
 
         # 카메라 구독
         self._frame_subscriptions = []

--- a/robot/src/robot_ui/robot_ui/widgets/data_collection.py
+++ b/robot/src/robot_ui/robot_ui/widgets/data_collection.py
@@ -3,13 +3,16 @@ from datetime import datetime
 from functools import partial
 from pathlib import Path
 
+import cv2
+import numpy as np
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QLabel, QPushButton, QProgressBar,
-    QDialog, QHBoxLayout,
+    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QProgressBar,
+    QDialog, QFrame, QGridLayout, QGroupBox, QScrollArea,
 )
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtCore import Qt, Signal, QObject
+from PySide6.QtGui import QImage, QPixmap
 from rclpy.logging import get_logger
-from sensor_msgs.msg import Image
+from sensor_msgs.msg import Image, JointState
 
 from ..utils import ApiClient
 from ..utils.joint_state_collector import JointStateCollector
@@ -17,11 +20,114 @@ from ..services import UploadService, MultiCameraRecordingService, ParquetWriter
 
 logger = get_logger('DataCollection')
 
+JOINT_NAMES = ['shoulder_pan', 'shoulder_lift', 'elbow_flex', 'wrist_flex', 'wrist_roll', 'gripper']
+_POS_MIN, _POS_MAX = 0, 4095
+
+
+# ─── Qt 스레드 안전 시그널 ─────────────────────────────────────────────────────
+
+class _FrameSignal(QObject):
+    received = Signal(str, object)  # role, np.ndarray
+
+
+class _JointSignal(QObject):
+    received = Signal(list)  # list[float]
+
+
+# ─── 카메라 표시 위젯 ──────────────────────────────────────────────────────────
+
+class _CameraWidget(QFrame):
+    def __init__(self, role: str, parent=None):
+        super().__init__(parent)
+        self.role = role
+        self.setStyleSheet("""
+            QFrame {
+                background-color: #2d2d2d;
+                border: 1px solid #3c3c3c;
+                border-radius: 6px;
+            }
+        """)
+        self.setMinimumSize(280, 210)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(4)
+
+        role_label = QLabel(role)
+        role_label.setStyleSheet("color: #9cdcfe; font-size: 11px; font-weight: 600;")
+        layout.addWidget(role_label)
+
+        self._image_label = QLabel()
+        self._image_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._image_label.setStyleSheet("background-color: #1e1e1e; border-radius: 4px; color: #555;")
+        self._image_label.setText('대기 중...')
+        layout.addWidget(self._image_label, 1)
+
+    def update_image(self, cv_image: np.ndarray):
+        size = self._image_label.size()
+        h, w = cv_image.shape[:2]
+        scale = min(size.width() / max(w, 1), size.height() / max(h, 1))
+        if scale > 0:
+            nw, nh = int(w * scale), int(h * scale)
+            img = cv2.resize(cv_image, (nw, nh))
+        else:
+            img = cv_image
+        rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+        rh, rw, ch = rgb.shape
+        q = QImage(rgb.data, rw, rh, ch * rw, QImage.Format.Format_RGB888)
+        self._image_label.setPixmap(QPixmap.fromImage(q))
+
+
+# ─── 관절 상태 행 (팔로워만) ───────────────────────────────────────────────────
+
+class _JointRow(QWidget):
+    def __init__(self, name: str, parent=None):
+        super().__init__(parent)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 1, 0, 1)
+        layout.setSpacing(6)
+
+        lbl = QLabel(name)
+        lbl.setFixedWidth(96)
+        lbl.setStyleSheet('color: #cccccc; font-size: 11px;')
+        layout.addWidget(lbl)
+
+        self._bar = QProgressBar()
+        self._bar.setRange(_POS_MIN, _POS_MAX)
+        self._bar.setValue(2048)
+        self._bar.setFixedHeight(12)
+        self._bar.setTextVisible(False)
+        self._bar.setStyleSheet("""
+            QProgressBar { border: 1px solid #3c3c3c; border-radius: 3px; background-color: #1e1e1e; }
+            QProgressBar::chunk { background-color: #1e4d3a; border-radius: 2px; }
+        """)
+        layout.addWidget(self._bar, 1)
+
+        self._val = QLabel('2048')
+        self._val.setFixedWidth(36)
+        self._val.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+        self._val.setStyleSheet('color: #4ec9b0; font-size: 10px; font-family: monospace;')
+        layout.addWidget(self._val)
+
+    def update_value(self, v: float):
+        iv = int(max(_POS_MIN, min(_POS_MAX, v)))
+        self._bar.setValue(iv)
+        self._val.setText(str(iv))
+
+
+# ─── 메인 패널 ────────────────────────────────────────────────────────────────
 
 class DataCollectionPanel(QWidget):
-    """데이터 수집 패널"""
+    """데이터 수집 패널 — 카메라 뷰, 관절 상태, 에피소드/시간 카운트다운 포함"""
 
     recording_finished = Signal()
+
+    # 페이즈 표시 스타일
+    _PHASE_STYLE = {
+        'recording': ('● 수집 중',  '#d32f2f', '#0e639c'),   # (text, dot_color, bar_color)
+        'waiting':   ('● 대기 중',  '#dcdcaa', '#6a4c00'),
+        'idle':      ('● 대기',     '#858585', '#3c3c3c'),
+    }
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -34,72 +140,175 @@ class DataCollectionPanel(QWidget):
         self.upload_service = UploadService(ApiClient())
         self._frame_subscriptions: list = []
         self.recording_task = None
+
+        self._frame_signal = _FrameSignal()
+        self._frame_signal.received.connect(self._on_frame)
+        self._joint_signal = _JointSignal()
+        self._joint_signal.received.connect(self._on_joints)
+        self._joint_sub = None
+
+        self._camera_widgets: dict[str, _CameraWidget] = {}
+        self._joint_rows: list[_JointRow] = []
+
         self._setup_ui()
 
+    # ------------------------------------------------------------------
+    # UI 구성
+    # ------------------------------------------------------------------
+
     def _setup_ui(self):
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(16, 16, 16, 16)
-        layout.setSpacing(16)
+        root = QVBoxLayout(self)
+        root.setContentsMargins(16, 16, 16, 16)
+        root.setSpacing(10)
 
+        # ── 제목 + 상태 배지 ──────────────────────────────────────────
+        header = QHBoxLayout()
         title = QLabel('Data Collection')
-        title.setStyleSheet("color: #ffffff; font-size: 18px; font-weight: 600;")
-        layout.addWidget(title)
+        title.setStyleSheet("color: #ffffff; font-size: 17px; font-weight: 600;")
+        header.addWidget(title)
+        header.addStretch()
+        self._phase_label = QLabel('● 대기')
+        self._phase_label.setStyleSheet("color: #858585; font-size: 13px; font-weight: 600;")
+        header.addWidget(self._phase_label)
+        root.addLayout(header)
 
-        self.status_label = QLabel('Ready to record')
-        self.status_label.setStyleSheet("color: #858585; font-size: 14px;")
-        layout.addWidget(self.status_label)
+        # ── 에피소드 + 남은 시간 한 줄 ───────────────────────────────
+        info_row = QHBoxLayout()
+        info_row.setSpacing(20)
+        self._episode_label = QLabel('에피소드 —')
+        self._episode_label.setStyleSheet("color: #cccccc; font-size: 12px;")
+        info_row.addWidget(self._episode_label)
+        self._time_label = QLabel('남은 시간 —')
+        self._time_label.setStyleSheet("color: #cccccc; font-size: 12px;")
+        info_row.addWidget(self._time_label)
+        info_row.addStretch()
+        self._status_label = QLabel('Ready to record')
+        self._status_label.setStyleSheet("color: #858585; font-size: 11px;")
+        info_row.addWidget(self._status_label)
+        root.addLayout(info_row)
 
-        self.progress_bar = QProgressBar()
-        self.progress_bar.setStyleSheet("""
-            QProgressBar {
-                border: 1px solid #3c3c3c;
-                border-radius: 4px;
-                background-color: #2d2d2d;
-                text-align: center;
-                color: #ffffff;
+        # ── 페이즈 카운트다운 바 ──────────────────────────────────────
+        self._phase_bar = QProgressBar()
+        self._phase_bar.setFixedHeight(8)
+        self._phase_bar.setTextVisible(False)
+        self._phase_bar.setRange(0, 1000)
+        self._phase_bar.setValue(0)
+        self._phase_bar.setStyleSheet(self._make_bar_style('#3c3c3c'))
+        root.addWidget(self._phase_bar)
+
+        # ── 에피소드 전체 진행 바 ─────────────────────────────────────
+        ep_row = QHBoxLayout()
+        ep_lbl = QLabel('전체 진행')
+        ep_lbl.setStyleSheet("color: #858585; font-size: 10px;")
+        ep_row.addWidget(ep_lbl)
+        self._progress_bar = QProgressBar()
+        self._progress_bar.setFixedHeight(8)
+        self._progress_bar.setTextVisible(False)
+        self._progress_bar.setRange(0, 1)
+        self._progress_bar.setValue(0)
+        self._progress_bar.setStyleSheet(self._make_bar_style('#0e639c'))
+        ep_row.addWidget(self._progress_bar, 1)
+        self._progress_label = QLabel('0 / 0')
+        self._progress_label.setStyleSheet("color: #858585; font-size: 10px;")
+        ep_row.addWidget(self._progress_label)
+        root.addLayout(ep_row)
+
+        # ── 메인 콘텐츠 (카메라 + 관절) ──────────────────────────────
+        content = QHBoxLayout()
+        content.setSpacing(12)
+
+        # 카메라 그리드
+        cam_frame = QFrame()
+        cam_frame.setStyleSheet("QFrame { background-color: transparent; }")
+        self._cam_layout = QGridLayout(cam_frame)
+        self._cam_layout.setContentsMargins(0, 0, 0, 0)
+        self._cam_layout.setSpacing(8)
+        content.addWidget(cam_frame, 3)
+
+        # 관절 상태 패널
+        joint_group = QGroupBox('팔로워암 관절 상태')
+        joint_group.setStyleSheet("""
+            QGroupBox {
+                color: #cccccc; font-size: 12px; font-weight: 600;
+                border: 1px solid #3c3c3c; border-radius: 6px;
+                margin-top: 8px; padding-top: 6px;
+                min-width: 200px;
             }
-            QProgressBar::chunk {
-                background-color: #0e639c;
-                border-radius: 3px;
-            }
+            QGroupBox::title { subcontrol-origin: margin; left: 8px; padding: 0 4px; }
         """)
-        self.progress_bar.setVisible(False)
-        layout.addWidget(self.progress_bar)
+        joint_layout = QVBoxLayout(joint_group)
+        joint_layout.setContentsMargins(8, 14, 8, 8)
+        joint_layout.setSpacing(2)
+        for name in JOINT_NAMES:
+            row = _JointRow(name)
+            self._joint_rows.append(row)
+            joint_layout.addWidget(row)
+        joint_layout.addStretch()
+        content.addWidget(joint_group, 1)
 
-        layout.addStretch()
+        root.addLayout(content, 1)
 
+        # ── Record 버튼 ───────────────────────────────────────────────
         self.record_btn = QPushButton('Record')
         self.record_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.record_btn.setFixedHeight(44)
         self.record_btn.setStyleSheet("""
             QPushButton {
-                background-color: #d32f2f;
-                color: #ffffff;
-                border: none;
-                border-radius: 4px;
-                padding: 12px 32px;
-                font-size: 16px;
-                font-weight: 600;
+                background-color: #d32f2f; color: #ffffff;
+                border: none; border-radius: 4px;
+                font-size: 15px; font-weight: 600;
             }
             QPushButton:hover { background-color: #e53935; }
             QPushButton:pressed { background-color: #b71c1c; }
-            QPushButton:disabled { background-color: #5c5c5c; }
+            QPushButton:disabled { background-color: #5c5c5c; color: #888; }
         """)
         self.record_btn.clicked.connect(self._on_record_clicked)
-        layout.addWidget(self.record_btn, alignment=Qt.AlignmentFlag.AlignCenter)
+        root.addWidget(self.record_btn)
 
-        layout.addStretch()
+    @staticmethod
+    def _make_bar_style(color: str) -> str:
+        return f"""
+            QProgressBar {{
+                border: none; border-radius: 4px;
+                background-color: #2d2d2d;
+            }}
+            QProgressBar::chunk {{
+                background-color: {color};
+                border-radius: 4px;
+            }}
+        """
+
+    # ------------------------------------------------------------------
+    # 카메라 위젯 동적 생성
+    # ------------------------------------------------------------------
+
+    def _rebuild_camera_grid(self, camera_roles: dict):
+        # 기존 위젯 제거
+        for w in self._camera_widgets.values():
+            self._cam_layout.removeWidget(w)
+            w.deleteLater()
+        self._camera_widgets.clear()
+
+        cols = 2
+        for idx, role in enumerate(camera_roles):
+            w = _CameraWidget(role)
+            self._camera_widgets[role] = w
+            self._cam_layout.addWidget(w, idx // cols, idx % cols)
 
     # ------------------------------------------------------------------
     # 공개 API
     # ------------------------------------------------------------------
 
     def set_ros_node(self, node):
-        """ROS2 노드 설정 — JointStateCollector 생성"""
         self.ros_node = node
         self.joint_collector = JointStateCollector(node)
+        # 팔로워 관절 상태 구독
+        self._joint_sub = node.create_subscription(
+            JointState, '/follower/joint_states',
+            lambda msg: self._joint_signal.received.emit(list(msg.position)), 10
+        )
 
     def set_recording_config(self, settings: dict):
-        """녹화 설정 저장 — 서비스 초기화"""
         self.settings = settings
 
         session_id  = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -119,15 +328,36 @@ class DataCollectionPanel(QWidget):
             metadata_service=metadata_service,
             parquet_writer=parquet_writer,
         )
+        self.recording_service.set_display_callback(
+            lambda role, img: self._frame_signal.received.emit(role, img)
+        )
         self.session_dir = session_dir
 
-        self.status_label.setText(
-            f"Ready: {settings['episodes']} episodes, "
-            f"{settings['data_length']}s each"
+        episodes = settings.get('episodes', 1)
+        self._progress_bar.setMaximum(episodes)
+        self._progress_bar.setValue(0)
+        self._progress_label.setText(f"0 / {episodes}")
+
+        self._rebuild_camera_grid(settings['camera_roles'])
+        self._status_label.setText(
+            f"준비: {episodes}개 에피소드 × {settings['data_length']}s"
         )
 
     # ------------------------------------------------------------------
-    # 내부 동작
+    # Qt 슬롯 — 스레드 안전
+    # ------------------------------------------------------------------
+
+    def _on_frame(self, role: str, img: np.ndarray):
+        if role in self._camera_widgets:
+            self._camera_widgets[role].update_image(img)
+
+    def _on_joints(self, positions: list):
+        for i, row in enumerate(self._joint_rows):
+            if i < len(positions):
+                row.update_value(positions[i])
+
+    # ------------------------------------------------------------------
+    # 수집 흐름
     # ------------------------------------------------------------------
 
     def _on_record_clicked(self):
@@ -142,16 +372,16 @@ class DataCollectionPanel(QWidget):
             logger.error("Recording service not configured. Call set_recording_config() first.")
             return
 
-        episodes = self.settings.get('episodes', 1)
+        episodes     = self.settings.get('episodes', 1)
         camera_roles = self.settings.get('camera_roles', {})
 
         self.is_recording = True
         self.record_btn.setEnabled(False)
-        self.progress_bar.setVisible(True)
-        self.progress_bar.setMaximum(episodes)
-        self.progress_bar.setValue(0)
+        self._progress_bar.setMaximum(episodes)
+        self._progress_bar.setValue(0)
+        self._progress_label.setText(f"0 / {episodes}")
 
-        # 카메라 role별 subscription 생성
+        # 카메라 구독
         self._frame_subscriptions = []
         for role, topic in camera_roles.items():
             sub = self.ros_node.create_subscription(
@@ -163,44 +393,80 @@ class DataCollectionPanel(QWidget):
         await self.recording_service.run(
             settings=self.settings,
             session_dir=self.session_dir,
-            on_status=self.status_label.setText,
-            on_progress=lambda idx: self.progress_bar.setValue(idx + 1),
+            on_status=self._on_status,
+            on_progress=self._on_progress,
             ask_result=self._ask_episode_result,
+            on_countdown=self._on_countdown,
         )
 
         for sub in self._frame_subscriptions:
             self.ros_node.destroy_subscription(sub)
         self._frame_subscriptions = []
 
-        self.progress_bar.setValue(episodes)
-        self.status_label.setText("Recording complete!")
+        self._progress_bar.setValue(episodes)
+        self._progress_label.setText(f"{episodes} / {episodes}")
+        self._update_phase('idle')
+        self._time_label.setText('완료')
+        self._status_label.setText('수집 완료!')
         self.is_recording = False
         self.record_btn.setEnabled(True)
         self.recording_finished.emit()
 
+    def _on_status(self, text: str):
+        self._status_label.setText(text)
+
+    def _on_progress(self, episode_idx: int):
+        done = episode_idx + 1
+        total = self.settings.get('episodes', 1)
+        self._progress_bar.setValue(done)
+        self._progress_label.setText(f"{done} / {total}")
+
+    def _on_countdown(self, phase: str, remaining: float, total: float, ep_idx: int, total_eps: int):
+        """수집/대기 카운트다운 매 0.1s 호출"""
+        self._update_phase(phase)
+        pct = int((1.0 - remaining / max(total, 0.001)) * 1000)
+        self._phase_bar.setValue(pct)
+        self._time_label.setText(f"남은 시간  {remaining:.1f}s")
+        self._episode_label.setText(f"에피소드  {ep_idx + 1} / {total_eps}")
+
+    def _update_phase(self, phase: str):
+        text, dot_color, bar_color = self._PHASE_STYLE.get(phase, self._PHASE_STYLE['idle'])
+        self._phase_label.setText(text)
+        self._phase_label.setStyleSheet(
+            f"color: {dot_color}; font-size: 13px; font-weight: 600;"
+        )
+        self._phase_bar.setStyleSheet(self._make_bar_style(bar_color))
+
+    # ------------------------------------------------------------------
+    # 에피소드 결과 팝업
+    # ------------------------------------------------------------------
+
     async def _ask_episode_result(self, episode_index: int) -> bool:
-        """에피소드 성공/실패 팝업 — asyncio 루프 블로킹 없이 Future로 대기"""
         loop   = asyncio.get_event_loop()
         future = loop.create_future()
 
         dialog = QDialog(self)
-        dialog.setWindowTitle(f"Episode {episode_index + 1} Result")
+        dialog.setWindowTitle(f"에피소드 {episode_index + 1} 결과")
         dialog.setStyleSheet("background-color: #2d2d2d; color: #ffffff;")
-        dialog.setFixedSize(300, 120)
+        dialog.setFixedSize(320, 130)
 
-        btn_layout = QHBoxLayout(dialog)
-        btn_layout.setContentsMargins(24, 24, 24, 24)
-        btn_layout.setSpacing(16)
+        outer = QVBoxLayout(dialog)
+        outer.setContentsMargins(24, 20, 24, 20)
+        outer.setSpacing(14)
 
-        label = QLabel(f"Episode {episode_index + 1} — Success?")
+        label = QLabel(f"에피소드 {episode_index + 1} — 성공했나요?")
         label.setStyleSheet("color: #ffffff; font-size: 14px;")
+        outer.addWidget(label)
 
-        success_btn = QPushButton("✓ Success")
+        btn_layout = QHBoxLayout()
+        btn_layout.setSpacing(12)
+
+        success_btn = QPushButton("✓ 성공")
         success_btn.setStyleSheet(
             "background-color: #388e3c; color: #fff; border: none; "
             "border-radius: 4px; padding: 8px 20px; font-size: 14px;"
         )
-        fail_btn = QPushButton("✗ Fail")
+        fail_btn = QPushButton("✗ 실패")
         fail_btn.setStyleSheet(
             "background-color: #d32f2f; color: #fff; border: none; "
             "border-radius: 4px; padding: 8px 20px; font-size: 14px;"
@@ -214,12 +480,9 @@ class DataCollectionPanel(QWidget):
         success_btn.clicked.connect(lambda: _resolve(True))
         fail_btn.clicked.connect(lambda: _resolve(False))
 
-        outer = QVBoxLayout()
-        outer.addWidget(label)
-        outer.addLayout(btn_layout)
         btn_layout.addWidget(success_btn)
         btn_layout.addWidget(fail_btn)
-        dialog.setLayout(outer)
+        outer.addLayout(btn_layout)
         dialog.show()
 
         return await asyncio.wrap_future(future)

--- a/robot/src/robot_ui/robot_ui/widgets/dataset_setting.py
+++ b/robot/src/robot_ui/robot_ui/widgets/dataset_setting.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime
 
 from PySide6.QtWidgets import (
@@ -52,7 +53,7 @@ class DatasetSettingPanel(QWidget):
         # Dataset Name
         self.dataset_name_edit = self._create_lineedit_row(
             settings_layout, 'Dataset Name',
-            datetime.now().strftime("dataset_%Y%m%d"),
+            datetime.now().strftime("dataset_%Y%m%d_%H%M%S"),
         )
 
         # Camera role → topic 매핑
@@ -189,6 +190,16 @@ class DatasetSettingPanel(QWidget):
     # ------------------------------------------------------------------
     # 공개 API
     # ------------------------------------------------------------------
+
+    # 자동생성 이름 패턴: dataset_YYYYMMDD 또는 dataset_YYYYMMDD_HHMMSS
+    _AUTO_NAME_RE = re.compile(r'^dataset_\d{8}(_\d{6})?$')
+
+    def showEvent(self, event):
+        """패널이 표시될 때 자동생성된 이름이면 현재 시각으로 갱신"""
+        super().showEvent(event)
+        current = self.dataset_name_edit.text().strip()
+        if not current or self._AUTO_NAME_RE.fullmatch(current):
+            self.dataset_name_edit.setText(datetime.now().strftime("dataset_%Y%m%d_%H%M%S"))
 
     def set_available_topics(self, topics: list[str]):
         """CameraPreviewArea refresh 결과로 ComboBox 목록 갱신"""

--- a/robot/src/robot_ui/robot_ui/widgets/dataset_setting.py
+++ b/robot/src/robot_ui/robot_ui/widgets/dataset_setting.py
@@ -1,8 +1,23 @@
+from datetime import datetime
+
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel, QSpinBox, QDoubleSpinBox,
-    QFrame, QPushButton
+    QFrame, QPushButton, QLineEdit, QComboBox
 )
 from PySide6.QtCore import Qt, Signal
+
+CAMERA_ROLES = ['top', 'wrist']
+
+LABEL_STYLE    = "color: #cccccc; font-size: 14px;"
+INPUT_STYLE    = """
+    background-color: #3c3c3c;
+    color: #ffffff;
+    border: 1px solid #5c5c5c;
+    border-radius: 4px;
+    padding: 6px 12px;
+    font-size: 14px;
+"""
+FOCUSED_BORDER = "border-color: #0e639c;"
 
 
 class DatasetSettingPanel(QWidget):
@@ -12,7 +27,7 @@ class DatasetSettingPanel(QWidget):
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.selected_topic: str = ""
+        self._camera_combos: dict[str, QComboBox] = {}
         self._setup_ui()
 
     def _setup_ui(self):
@@ -22,24 +37,8 @@ class DatasetSettingPanel(QWidget):
 
         # 헤더
         title = QLabel('Dataset Setting')
-        title.setStyleSheet("""
-            QLabel {
-                color: #ffffff;
-                font-size: 18px;
-                font-weight: 600;
-            }
-        """)
+        title.setStyleSheet("color: #ffffff; font-size: 18px; font-weight: 600;")
         layout.addWidget(title)
-
-        # 선택된 카메라 표시
-        self.camera_label = QLabel('No camera selected')
-        self.camera_label.setStyleSheet("""
-            QLabel {
-                color: #858585;
-                font-size: 14px;
-            }
-        """)
-        layout.addWidget(self.camera_label)
 
         # 구분선
         separator = QFrame()
@@ -47,21 +46,36 @@ class DatasetSettingPanel(QWidget):
         separator.setStyleSheet("background-color: #3c3c3c;")
         layout.addWidget(separator)
 
-        # 설정 영역
         settings_layout = QVBoxLayout()
         settings_layout.setSpacing(12)
 
-        # 에피소드 개수
+        # Dataset Name
+        self.dataset_name_edit = self._create_lineedit_row(
+            settings_layout, 'Dataset Name',
+            datetime.now().strftime("dataset_%Y%m%d"),
+        )
+
+        # Camera role → topic 매핑
+        for role in CAMERA_ROLES:
+            combo = self._create_combo_row(settings_layout, f'Camera: {role}')
+            self._camera_combos[role] = combo
+
+        # Language Instruction
+        self.language_edit = self._create_lineedit_row(
+            settings_layout, 'Language Instruction', ''
+        )
+
+        # Episodes
         self.episode_spin = self._create_spin_row(
             settings_layout, 'Episodes', 1, 1000, 10
         )
 
-        # Data 길이 (초)
+        # Data Length (초)
         self.data_length_spin = self._create_double_spin_row(
             settings_layout, 'Data Length (sec)', 0.1, 3600.0, 10.0
         )
 
-        # Term 길이 (초)
+        # Term Length (초)
         self.term_length_spin = self._create_double_spin_row(
             settings_layout, 'Term Length (sec)', 0.0, 3600.0, 1.0
         )
@@ -83,49 +97,69 @@ class DatasetSettingPanel(QWidget):
                 font-size: 14px;
                 font-weight: 600;
             }
-            QPushButton:hover {
-                background-color: #1177bb;
-            }
-            QPushButton:pressed {
-                background-color: #094771;
-            }
+            QPushButton:hover { background-color: #1177bb; }
+            QPushButton:pressed { background-color: #094771; }
         """)
         self.submit_btn.clicked.connect(self._on_submit)
         btn_layout.addWidget(self.submit_btn)
         btn_layout.addStretch()
         layout.addLayout(btn_layout)
 
+    # ------------------------------------------------------------------
+    # 위젯 팩토리
+    # ------------------------------------------------------------------
+
+    def _create_lineedit_row(
+        self, parent_layout: QVBoxLayout, label: str, default: str
+    ) -> QLineEdit:
+        row = QHBoxLayout()
+        lbl = QLabel(label)
+        lbl.setStyleSheet(LABEL_STYLE)
+        lbl.setFixedWidth(160)
+        row.addWidget(lbl)
+
+        edit = QLineEdit(default)
+        edit.setStyleSheet(f"QLineEdit {{ {INPUT_STYLE} }} QLineEdit:focus {{ {FOCUSED_BORDER} }}")
+        edit.setFixedWidth(200)
+        row.addWidget(edit)
+        row.addStretch()
+        parent_layout.addLayout(row)
+        return edit
+
+    def _create_combo_row(
+        self, parent_layout: QVBoxLayout, label: str
+    ) -> QComboBox:
+        row = QHBoxLayout()
+        lbl = QLabel(label)
+        lbl.setStyleSheet(LABEL_STYLE)
+        lbl.setFixedWidth(160)
+        row.addWidget(lbl)
+
+        combo = QComboBox()
+        combo.addItem('')  # 선택 안 함
+        combo.setStyleSheet(f"QComboBox {{ {INPUT_STYLE} }} QComboBox:focus {{ {FOCUSED_BORDER} }}")
+        combo.setFixedWidth(200)
+        row.addWidget(combo)
+        row.addStretch()
+        parent_layout.addLayout(row)
+        return combo
+
     def _create_spin_row(
         self, parent_layout: QVBoxLayout, label: str,
         min_val: int, max_val: int, default: int
     ) -> QSpinBox:
-        """정수 입력 행 생성"""
         row = QHBoxLayout()
-
         lbl = QLabel(label)
-        lbl.setStyleSheet("color: #cccccc; font-size: 14px;")
-        lbl.setFixedWidth(150)
+        lbl.setStyleSheet(LABEL_STYLE)
+        lbl.setFixedWidth(160)
         row.addWidget(lbl)
 
         spin = QSpinBox()
         spin.setRange(min_val, max_val)
         spin.setValue(default)
-        spin.setStyleSheet("""
-            QSpinBox {
-                background-color: #3c3c3c;
-                color: #ffffff;
-                border: 1px solid #5c5c5c;
-                border-radius: 4px;
-                padding: 6px 12px;
-                font-size: 14px;
-            }
-            QSpinBox:focus {
-                border-color: #0e639c;
-            }
-        """)
+        spin.setStyleSheet(f"QSpinBox {{ {INPUT_STYLE} }} QSpinBox:focus {{ {FOCUSED_BORDER} }}")
         spin.setFixedWidth(120)
         row.addWidget(spin)
-
         row.addStretch()
         parent_layout.addLayout(row)
         return spin
@@ -134,12 +168,10 @@ class DatasetSettingPanel(QWidget):
         self, parent_layout: QVBoxLayout, label: str,
         min_val: float, max_val: float, default: float
     ) -> QDoubleSpinBox:
-        """실수 입력 행 생성"""
         row = QHBoxLayout()
-
         lbl = QLabel(label)
-        lbl.setStyleSheet("color: #cccccc; font-size: 14px;")
-        lbl.setFixedWidth(150)
+        lbl.setStyleSheet(LABEL_STYLE)
+        lbl.setFixedWidth(160)
         row.addWidget(lbl)
 
         spin = QDoubleSpinBox()
@@ -147,41 +179,44 @@ class DatasetSettingPanel(QWidget):
         spin.setValue(default)
         spin.setDecimals(1)
         spin.setSingleStep(0.5)
-        spin.setStyleSheet("""
-            QDoubleSpinBox {
-                background-color: #3c3c3c;
-                color: #ffffff;
-                border: 1px solid #5c5c5c;
-                border-radius: 4px;
-                padding: 6px 12px;
-                font-size: 14px;
-            }
-            QDoubleSpinBox:focus {
-                border-color: #0e639c;
-            }
-        """)
+        spin.setStyleSheet(f"QDoubleSpinBox {{ {INPUT_STYLE} }} QDoubleSpinBox:focus {{ {FOCUSED_BORDER} }}")
         spin.setFixedWidth(120)
         row.addWidget(spin)
-
         row.addStretch()
         parent_layout.addLayout(row)
         return spin
 
-    def set_camera(self, topic_name: str):
-        """선택된 카메라 설정"""
-        self.selected_topic = topic_name
-        self.camera_label.setText(f'Selected: {topic_name}')
+    # ------------------------------------------------------------------
+    # 공개 API
+    # ------------------------------------------------------------------
 
-    def _on_submit(self):
-        """Submit 버튼 클릭 시"""
-        settings = self.get_settings()
-        settings['topic'] = self.selected_topic
-        self.submitted.emit(settings)
+    def set_available_topics(self, topics: list[str]):
+        """CameraPreviewArea refresh 결과로 ComboBox 목록 갱신"""
+        for combo in self._camera_combos.values():
+            current = combo.currentText()
+            combo.clear()
+            combo.addItem('')  # 선택 안 함
+            for t in topics:
+                combo.addItem(t)
+            idx = combo.findText(current)
+            combo.setCurrentIndex(idx if idx >= 0 else 0)
 
     def get_settings(self) -> dict:
         """현재 설정값 반환"""
+        camera_roles = {}
+        for role, combo in self._camera_combos.items():
+            topic = combo.currentText()
+            if topic:
+                camera_roles[role] = topic
+
         return {
-            'episodes': self.episode_spin.value(),
-            'data_length': self.data_length_spin.value(),
-            'term_length': self.term_length_spin.value(),
+            'dataset_name':        self.dataset_name_edit.text().strip(),
+            'camera_roles':        camera_roles,
+            'language_instruction': self.language_edit.text().strip(),
+            'episodes':            self.episode_spin.value(),
+            'data_length':         self.data_length_spin.value(),
+            'term_length':         self.term_length_spin.value(),
         }
+
+    def _on_submit(self):
+        self.submitted.emit(self.get_settings())

--- a/robot/src/robot_ui/test/test_joint_state_collector.py
+++ b/robot/src/robot_ui/test/test_joint_state_collector.py
@@ -1,0 +1,160 @@
+"""
+JointStateCollector 유닛 테스트 — ROS2 없이 실행 가능.
+pytest robot/src/robot_ui/test/test_joint_state_collector.py
+"""
+import sys
+import types
+from collections import deque
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# ROS2 stub — sensor_msgs, rclpy 없는 환경에서도 import 가능하게
+# ---------------------------------------------------------------------------
+
+def _make_ros_stubs():
+    sensor_msgs = types.ModuleType("sensor_msgs")
+    sensor_msgs.msg = types.ModuleType("sensor_msgs.msg")
+    sensor_msgs.msg.JointState = MagicMock
+
+    rclpy = types.ModuleType("rclpy")
+    rclpy.node = types.ModuleType("rclpy.node")
+    rclpy.node.Node = MagicMock
+
+    sys.modules.setdefault("sensor_msgs", sensor_msgs)
+    sys.modules.setdefault("sensor_msgs.msg", sensor_msgs.msg)
+    sys.modules.setdefault("rclpy", rclpy)
+    sys.modules.setdefault("rclpy.node", rclpy.node)
+
+
+_make_ros_stubs()
+
+# stub 등록 후 import
+import importlib.util
+_root = __import__("pathlib").Path(__file__).parents[1]
+_spec = importlib.util.spec_from_file_location(
+    "joint_state_collector",
+    _root / "robot_ui/utils/joint_state_collector.py",
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+JointStateCollector = _mod.JointStateCollector
+
+
+# ---------------------------------------------------------------------------
+# 헬퍼
+# ---------------------------------------------------------------------------
+
+def _make_collector() -> JointStateCollector:
+    node = MagicMock()
+    node.create_subscription.return_value = MagicMock()
+    return JointStateCollector(node)
+
+
+def _fill(collector: JointStateCollector, leader_data, follower_data):
+    """버퍼에 직접 데이터 주입"""
+    collector._leader_buf.extend(leader_data)
+    collector._follower_buf.extend(follower_data)
+
+
+# ---------------------------------------------------------------------------
+# 테스트
+# ---------------------------------------------------------------------------
+
+class TestStartEpisode:
+    def test_clears_buffers(self):
+        c = _make_collector()
+        _fill(c, [(0.0, [1.0] * 6)], [(0.0, [2.0] * 6)])
+        c.start_episode()
+        assert len(c._leader_buf) == 0
+        assert len(c._follower_buf) == 0
+
+
+class TestCallbacks:
+    def test_on_leader_appends(self):
+        c = _make_collector()
+        msg = MagicMock()
+        msg.position = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.99]  # 7개, 6개만 사용
+        c._on_leader(msg)
+        assert len(c._leader_buf) == 1
+        _, pos = c._leader_buf[0]
+        assert pos == [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
+
+    def test_on_follower_appends(self):
+        c = _make_collector()
+        msg = MagicMock()
+        msg.position = [1.0] * 7
+        c._on_follower(msg)
+        assert len(c._follower_buf) == 1
+        _, pos = c._follower_buf[0]
+        assert pos == [1.0] * 6
+
+
+class TestAlignToFrames:
+    def test_nearest_neighbor_basic(self):
+        """플랜 명세 검증: 0.04→0.0, 0.09→0.1 에 nearest"""
+        c = _make_collector()
+        _fill(
+            c,
+            leader_data=[(0.0, [1.0] * 6), (0.1, [2.0] * 6)],
+            follower_data=[(0.05, [3.0] * 6)],
+        )
+        result = c.align_to_frames([0.04, 0.09])
+
+        assert result[0]["action"] == [1.0] * 6   # 0.04 → 0.0 더 가까움
+        assert result[1]["action"] == [2.0] * 6   # 0.09 → 0.1 더 가까움
+        assert result[0]["obs_state"] == [3.0] * 6
+        assert result[1]["obs_state"] == [3.0] * 6
+
+    def test_result_length_matches_frames(self):
+        c = _make_collector()
+        _fill(
+            c,
+            leader_data=[(i * 0.1, [float(i)] * 6) for i in range(5)],
+            follower_data=[(i * 0.1, [float(i)] * 6) for i in range(5)],
+        )
+        result = c.align_to_frames([0.05, 0.15, 0.25])
+        assert len(result) == 3
+
+    def test_empty_frames_returns_empty(self):
+        c = _make_collector()
+        _fill(c, [(0.0, [1.0] * 6)], [(0.0, [1.0] * 6)])
+        assert c.align_to_frames([]) == []
+
+    def test_raises_if_no_leader_data(self):
+        c = _make_collector()
+        _fill(c, leader_data=[], follower_data=[(0.0, [1.0] * 6)])
+        with pytest.raises(ValueError, match="/leader/joint_states"):
+            c.align_to_frames([0.0])
+
+    def test_raises_if_no_follower_data(self):
+        c = _make_collector()
+        _fill(c, leader_data=[(0.0, [1.0] * 6)], follower_data=[])
+        with pytest.raises(ValueError, match="/follower/joint_states"):
+            c.align_to_frames([0.0])
+
+    def test_single_sample_always_selected(self):
+        """샘플이 하나뿐이면 어떤 타임스탬프든 그 샘플을 반환"""
+        c = _make_collector()
+        _fill(c, [(99.0, [7.0] * 6)], [(99.0, [8.0] * 6)])
+        result = c.align_to_frames([0.0, 50.0, 200.0])
+        assert all(r["action"] == [7.0] * 6 for r in result)
+        assert all(r["obs_state"] == [8.0] * 6 for r in result)
+
+
+class TestDestroy:
+    def test_destroy_calls_unsubscribe(self):
+        node = MagicMock()
+        sub_leader = MagicMock()
+        sub_follower = MagicMock()
+        node.create_subscription.side_effect = [sub_leader, sub_follower]
+
+        c = JointStateCollector(node)
+        c.destroy()
+
+        node.destroy_subscription.assert_any_call(sub_leader)
+        node.destroy_subscription.assert_any_call(sub_follower)
+        assert node.destroy_subscription.call_count == 2

--- a/robot/src/robot_ui/test/test_metadata_service.py
+++ b/robot/src/robot_ui/test/test_metadata_service.py
@@ -1,0 +1,199 @@
+"""
+MetadataService 유닛 테스트 — ROS2 없이 실행 가능.
+pytest src/robot_ui/test/test_metadata_service.py
+"""
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# 직접 import (utils/__init__ 체인 우회)
+# ---------------------------------------------------------------------------
+_root = Path(__file__).parents[1]
+
+
+def _load_module(name: str, rel_path: str):
+    spec = importlib.util.spec_from_file_location(name, _root / rel_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# parquet_service가 JOINT_NAMES를 export하므로 먼저 로드
+_parquet_mod = _load_module("parquet_service", "robot_ui/services/parquet_service.py")
+
+# metadata_service는 .parquet_service를 relative import — sys.modules에 등록 후 로드
+import sys
+sys.modules.setdefault("parquet_service", _parquet_mod)
+
+# metadata_service의 relative import를 우회하기 위해 parquet_service를 패치
+import importlib
+_meta_path = _root / "robot_ui/services/metadata_service.py"
+_meta_src = _meta_path.read_text().replace(
+    "from .parquet_service import JOINT_NAMES",
+    "from parquet_service import JOINT_NAMES",
+)
+_meta_spec = importlib.util.spec_from_loader("metadata_service", loader=None)
+_meta_mod = importlib.util.module_from_spec(
+    importlib.util.spec_from_file_location("metadata_service", _meta_path)
+)
+exec(compile(_meta_src, str(_meta_path), "exec"), _meta_mod.__dict__)
+
+MetadataService = _meta_mod.MetadataService
+_atomic_write_json = _meta_mod._atomic_write_json
+INFO_TEMPLATE = _meta_mod.INFO_TEMPLATE
+
+
+# ---------------------------------------------------------------------------
+# 헬퍼
+# ---------------------------------------------------------------------------
+
+def _make_service(tmp_path: Path, camera_roles=None, fps=30) -> tuple:
+    if camera_roles is None:
+        camera_roles = {"top": "/camera_0/image_raw"}
+    svc = MetadataService()
+    offset = svc.load_or_init(tmp_path / "meta", camera_roles, fps)
+    return svc, offset
+
+
+# ---------------------------------------------------------------------------
+# 테스트
+# ---------------------------------------------------------------------------
+
+class TestLoadOrInit:
+    def test_creates_info_json_on_first_call(self, tmp_path):
+        svc, _ = _make_service(tmp_path)
+        assert (tmp_path / "meta" / "info.json").exists()
+
+    def test_returns_zero_offset_on_new_session(self, tmp_path):
+        _, offset = _make_service(tmp_path)
+        assert offset == 0
+
+    def test_info_json_has_required_fields(self, tmp_path):
+        _make_service(tmp_path)
+        info = json.loads((tmp_path / "meta" / "info.json").read_text())
+        for key in ("codebase_version", "robot_type", "fps", "features",
+                    "total_episodes", "total_frames", "total_successes", "splits"):
+            assert key in info
+
+    def test_camera_roles_added_to_features(self, tmp_path):
+        _make_service(tmp_path, camera_roles={"top": "/cam0", "wrist": "/cam2"})
+        info = json.loads((tmp_path / "meta" / "info.json").read_text())
+        assert "observation.images.top" in info["features"]
+        assert "observation.images.wrist" in info["features"]
+
+    def test_fps_stored_correctly(self, tmp_path):
+        _make_service(tmp_path, fps=15)
+        info = json.loads((tmp_path / "meta" / "info.json").read_text())
+        assert info["fps"] == 15
+
+    def test_loads_existing_info_json(self, tmp_path):
+        meta_dir = tmp_path / "meta"
+        meta_dir.mkdir()
+        existing = dict(INFO_TEMPLATE)
+        existing["total_frames"] = 999
+        existing["total_episodes"] = 5
+        (meta_dir / "info.json").write_text(json.dumps(existing))
+
+        svc, offset = _make_service(tmp_path)
+        assert offset == 999
+
+    def test_no_tmp_file_left_after_init(self, tmp_path):
+        _make_service(tmp_path)
+        assert not (tmp_path / "meta" / "info.tmp").exists()
+
+
+class TestAppendEpisode:
+    def test_episodes_jsonl_created(self, tmp_path):
+        svc, _ = _make_service(tmp_path)
+        svc.append_episode(0, 300, True, "pick block", 0)
+        assert (tmp_path / "meta" / "episodes.jsonl").exists()
+
+    def test_jsonl_line_count_matches_episodes(self, tmp_path):
+        svc, _ = _make_service(tmp_path)
+        svc.append_episode(0, 100, True, "task", 0)
+        svc.append_episode(1, 120, False, "task", 0)
+        svc.append_episode(2, 90, True, "task", 0)
+        lines = (tmp_path / "meta" / "episodes.jsonl").read_text().strip().splitlines()
+        assert len(lines) == 3
+
+    def test_jsonl_record_fields(self, tmp_path):
+        svc, _ = _make_service(tmp_path)
+        svc.append_episode(0, 300, True, "pick block", 0)
+        record = json.loads(
+            (tmp_path / "meta" / "episodes.jsonl").read_text().strip()
+        )
+        assert record["episode_index"] == 0
+        assert record["length"] == 300
+        assert record["success"] is True
+        assert record["language_instruction"] == "pick block"
+        assert record["chunk_index"] == 0
+        assert "timestamp" in record
+
+    def test_info_json_total_episodes_increments(self, tmp_path):
+        svc, _ = _make_service(tmp_path)
+        svc.append_episode(0, 100, True, "task", 0)
+        svc.append_episode(1, 100, True, "task", 0)
+        info = json.loads((tmp_path / "meta" / "info.json").read_text())
+        assert info["total_episodes"] == 2
+
+    def test_info_json_total_frames_accumulates(self, tmp_path):
+        svc, _ = _make_service(tmp_path)
+        svc.append_episode(0, 100, True, "task", 0)
+        svc.append_episode(1, 200, True, "task", 0)
+        info = json.loads((tmp_path / "meta" / "info.json").read_text())
+        assert info["total_frames"] == 300
+
+    def test_total_successes_counts_only_success(self, tmp_path):
+        svc, _ = _make_service(tmp_path)
+        svc.append_episode(0, 100, True, "task", 0)
+        svc.append_episode(1, 100, False, "task", 0)
+        svc.append_episode(2, 100, True, "task", 0)
+        info = json.loads((tmp_path / "meta" / "info.json").read_text())
+        assert info["total_successes"] == 2
+
+    def test_no_tmp_file_left_after_append(self, tmp_path):
+        svc, _ = _make_service(tmp_path)
+        svc.append_episode(0, 100, True, "task", 0)
+        assert not (tmp_path / "meta" / "info.tmp").exists()
+
+    def test_append_is_idempotent_on_file(self, tmp_path):
+        """각 호출이 전체 파일을 덮어쓰지 않고 1줄만 추가하는지 확인"""
+        svc, _ = _make_service(tmp_path)
+        svc.append_episode(0, 100, True, "task", 0)
+        first_line = (tmp_path / "meta" / "episodes.jsonl").read_text().splitlines()[0]
+        svc.append_episode(1, 200, False, "task", 0)
+        lines = (tmp_path / "meta" / "episodes.jsonl").read_text().splitlines()
+        assert lines[0] == first_line  # 첫 줄이 변경되지 않음
+        assert len(lines) == 2
+
+
+class TestFinalize:
+    def test_splits_updated_to_train_range(self, tmp_path):
+        svc, _ = _make_service(tmp_path)
+        svc.append_episode(0, 100, True, "task", 0)
+        svc.append_episode(1, 100, True, "task", 0)
+        svc.finalize()
+        info = json.loads((tmp_path / "meta" / "info.json").read_text())
+        assert info["splits"] == {"train": "0:2"}
+
+    def test_finalize_zero_episodes(self, tmp_path):
+        svc, _ = _make_service(tmp_path)
+        svc.finalize()
+        info = json.loads((tmp_path / "meta" / "info.json").read_text())
+        assert info["splits"] == {"train": "0:0"}
+
+
+class TestAtomicWrite:
+    def test_atomic_write_creates_file(self, tmp_path):
+        path = tmp_path / "test.json"
+        _atomic_write_json(path, {"key": "value"})
+        assert path.exists()
+        assert json.loads(path.read_text()) == {"key": "value"}
+
+    def test_atomic_write_no_tmp_file_left(self, tmp_path):
+        path = tmp_path / "test.json"
+        _atomic_write_json(path, {})
+        assert not (tmp_path / "test.tmp").exists()

--- a/robot/src/robot_ui/test/test_parquet_service.py
+++ b/robot/src/robot_ui/test/test_parquet_service.py
@@ -1,0 +1,184 @@
+"""
+ParquetWriter 유닛 테스트 — ROS2 없이 실행 가능.
+pytest src/robot_ui/test/test_parquet_service.py
+"""
+import importlib.util
+from pathlib import Path
+
+import pyarrow.parquet as pq
+import pytest
+
+# ---------------------------------------------------------------------------
+# 직접 import (utils/__init__ 체인 우회)
+# ---------------------------------------------------------------------------
+_root = Path(__file__).parents[1]
+_spec = importlib.util.spec_from_file_location(
+    "parquet_service",
+    _root / "robot_ui/services/parquet_service.py",
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+ParquetWriter = _mod.ParquetWriter
+SCHEMA        = _mod.SCHEMA
+JOINT_NAMES   = _mod.JOINT_NAMES
+
+
+# ---------------------------------------------------------------------------
+# 헬퍼
+# ---------------------------------------------------------------------------
+
+def _make_joint_records(n: int, action_val=1.0, obs_val=2.0) -> list[dict]:
+    return [{"action": [action_val] * 6, "obs_state": [obs_val] * 6} for _ in range(n)]
+
+
+def _make_timestamps(n: int, start=0.0, step=1/30) -> list[float]:
+    return [start + i * step for i in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# 테스트
+# ---------------------------------------------------------------------------
+
+class TestParquetWriterSchema:
+    def test_output_file_created(self, tmp_path):
+        w = ParquetWriter()
+        out = tmp_path / "ep.parquet"
+        w.write(out, 0, _make_joint_records(5), _make_timestamps(5), "test", True)
+        assert out.exists()
+
+    def test_schema_matches(self, tmp_path):
+        w = ParquetWriter()
+        out = tmp_path / "ep.parquet"
+        w.write(out, 0, _make_joint_records(3), _make_timestamps(3), "test", True)
+        table = pq.read_table(out)
+        assert table.schema.equals(SCHEMA)
+
+    def test_all_expected_columns_present(self, tmp_path):
+        w = ParquetWriter()
+        out = tmp_path / "ep.parquet"
+        w.write(out, 0, _make_joint_records(2), _make_timestamps(2), "test", True)
+        table = pq.read_table(out)
+        expected = {f.name for f in SCHEMA}
+        assert set(table.schema.names) == expected
+
+
+class TestParquetWriterRows:
+    def test_row_count_equals_min_of_records_and_timestamps(self, tmp_path):
+        w = ParquetWriter()
+        out = tmp_path / "ep.parquet"
+        # joint_records가 더 많을 때 → timestamps 기준
+        w.write(out, 0, _make_joint_records(10), _make_timestamps(7), "test", True)
+        table = pq.read_table(out)
+        assert len(table) == 7
+
+    def test_frame_index_is_sequential(self, tmp_path):
+        w = ParquetWriter()
+        out = tmp_path / "ep.parquet"
+        w.write(out, 0, _make_joint_records(5), _make_timestamps(5), "test", True)
+        table = pq.read_table(out)
+        assert table["frame_index"].to_pylist() == list(range(5))
+
+    def test_episode_index_constant(self, tmp_path):
+        w = ParquetWriter()
+        out = tmp_path / "ep.parquet"
+        w.write(out, 3, _make_joint_records(4), _make_timestamps(4), "test", True)
+        table = pq.read_table(out)
+        assert all(v == 3 for v in table["episode_index"].to_pylist())
+
+
+class TestParquetWriterDoneReward:
+    def test_next_done_only_last_frame(self, tmp_path):
+        w = ParquetWriter()
+        out = tmp_path / "ep.parquet"
+        w.write(out, 0, _make_joint_records(5), _make_timestamps(5), "test", True)
+        table = pq.read_table(out)
+        done = table["next.done"].to_pylist()
+        assert done[-1] is True
+        assert all(v is False for v in done[:-1])
+
+    def test_next_success_true_only_on_last_frame_when_success(self, tmp_path):
+        w = ParquetWriter()
+        out = tmp_path / "ep.parquet"
+        w.write(out, 0, _make_joint_records(4), _make_timestamps(4), "test", success=True)
+        table = pq.read_table(out)
+        success_col = table["next.success"].to_pylist()
+        assert success_col[-1] is True
+        assert all(v is False for v in success_col[:-1])
+
+    def test_next_success_false_when_failure(self, tmp_path):
+        w = ParquetWriter()
+        out = tmp_path / "ep.parquet"
+        w.write(out, 0, _make_joint_records(4), _make_timestamps(4), "test", success=False)
+        table = pq.read_table(out)
+        assert all(v is False for v in table["next.success"].to_pylist())
+
+    def test_next_reward_1_on_last_frame_when_success(self, tmp_path):
+        w = ParquetWriter()
+        out = tmp_path / "ep.parquet"
+        w.write(out, 0, _make_joint_records(3), _make_timestamps(3), "test", success=True)
+        table = pq.read_table(out)
+        reward = table["next.reward"].to_pylist()
+        assert reward[-1] == pytest.approx(1.0)
+        assert all(v == pytest.approx(0.0) for v in reward[:-1])
+
+    def test_next_reward_0_on_all_when_failure(self, tmp_path):
+        w = ParquetWriter()
+        out = tmp_path / "ep.parquet"
+        w.write(out, 0, _make_joint_records(3), _make_timestamps(3), "test", success=False)
+        table = pq.read_table(out)
+        assert all(v == pytest.approx(0.0) for v in table["next.reward"].to_pylist())
+
+
+class TestParquetWriterGlobalOffset:
+    def test_index_starts_at_offset(self, tmp_path):
+        w = ParquetWriter(global_frame_offset=100)
+        out = tmp_path / "ep.parquet"
+        w.write(out, 0, _make_joint_records(5), _make_timestamps(5), "test", True)
+        table = pq.read_table(out)
+        assert table["index"].to_pylist() == list(range(100, 105))
+
+    def test_offset_advances_after_write(self, tmp_path):
+        w = ParquetWriter()
+        w.write(tmp_path / "ep0.parquet", 0, _make_joint_records(10), _make_timestamps(10), "test", True)
+        assert w.get_global_offset() == 10
+        w.write(tmp_path / "ep1.parquet", 1, _make_joint_records(5), _make_timestamps(5), "test", True)
+        assert w.get_global_offset() == 15
+
+    def test_index_continuous_across_episodes(self, tmp_path):
+        w = ParquetWriter()
+        w.write(tmp_path / "ep0.parquet", 0, _make_joint_records(3), _make_timestamps(3), "test", True)
+        w.write(tmp_path / "ep1.parquet", 1, _make_joint_records(3), _make_timestamps(3), "test", True)
+        t0 = pq.read_table(tmp_path / "ep0.parquet")
+        t1 = pq.read_table(tmp_path / "ep1.parquet")
+        assert t0["index"].to_pylist() == [0, 1, 2]
+        assert t1["index"].to_pylist() == [3, 4, 5]
+
+
+class TestParquetWriterJointData:
+    def test_action_values_stored(self, tmp_path):
+        w = ParquetWriter()
+        out = tmp_path / "ep.parquet"
+        records = [{"action": [float(i)] * 6, "obs_state": [0.0] * 6} for i in range(3)]
+        w.write(out, 0, records, _make_timestamps(3), "test", True)
+        table = pq.read_table(out)
+        action_col = table["action"].to_pylist()
+        assert action_col[0] == pytest.approx([0.0] * 6)
+        assert action_col[1] == pytest.approx([1.0] * 6)
+        assert action_col[2] == pytest.approx([2.0] * 6)
+
+    def test_observation_state_values_stored(self, tmp_path):
+        w = ParquetWriter()
+        out = tmp_path / "ep.parquet"
+        records = [{"action": [0.0] * 6, "obs_state": [float(i)] * 6} for i in range(3)]
+        w.write(out, 0, records, _make_timestamps(3), "test", True)
+        table = pq.read_table(out)
+        obs_col = table["observation.state"].to_pylist()
+        assert obs_col[2] == pytest.approx([2.0] * 6)
+
+    def test_language_instruction_stored(self, tmp_path):
+        w = ParquetWriter()
+        out = tmp_path / "ep.parquet"
+        w.write(out, 0, _make_joint_records(2), _make_timestamps(2), "pick the red block", True)
+        table = pq.read_table(out)
+        assert all(v == "pick the red block" for v in table["language_instruction"].to_pylist())

--- a/server/app/api/v1/objects.py
+++ b/server/app/api/v1/objects.py
@@ -23,7 +23,8 @@ async def get_upload_url(
 ):
     try:
         url = service.create_presigned_upload_url(
-            object_key=request.object_name
+            object_key=request.object_name,
+            content_type=request.content_type,
         )
         return PresignedUrlResponse(url=url)
     except Exception as e:

--- a/server/app/schemas/object.py
+++ b/server/app/schemas/object.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel
 
 class PresignedUploadUrlRequest(BaseModel):
     object_name: str
+    content_type: str = "application/octet-stream"
 
 class PresignedUrlResponse(BaseModel):
     url: str

--- a/server/app/services/object_service.py
+++ b/server/app/services/object_service.py
@@ -4,13 +4,13 @@ class ObjectService:
     def __init__(self, s3_client):
         self.client = s3_client
 
-    def create_presigned_upload_url(self, object_key: str) -> str:
+    def create_presigned_upload_url(self, object_key: str, content_type: str = "application/octet-stream") -> str:
         url = self.client.generate_presigned_url(
             "put_object",
             Params={
                 "Bucket": settings.S3_BUCKET_NAME,
                 "Key": object_key,
-                "ContentType": "video/mp4",
+                "ContentType": content_type,
             },
             ExpiresIn=settings.PRESIGNED_URL_EXPIRE_MINUTES * 60,
         )


### PR DESCRIPTION
## Summary (한 줄 요약)
- 멀티 카메라 영상과 관절 상태를 LeRobot 포맷(Parquet + MP4)으로 수집·인코딩·업로드하는 전체 파이프라인 구현

## Background / Why (배경)
- LeRobot으로 로봇을 학습시키려면 demonstration 데이터를 LeRobot 형식(Parquet + MP4 + info.json + episodes.jsonl)으로 수집해야 함
- 기존 `DataCollectionPanel`은 단일 카메라 단순 녹화 수준이었으며 관절 데이터 수집, 포맷 변환, 메타데이터 관리 기능 없음

## What Changed (변경 내용)

### 추가

**백엔드 서비스**
- `MultiCameraRecordingService` — 수집(producer)과 인코딩·업로드(consumer)를 `asyncio.Queue`로 분리해 동시 실행. 프레임을 PNG로 저장 후 ffmpeg로 AV1(또는 H264) MP4 인코딩
- `JointStateCollector` — `/leader/joint_states`, `/follower/joint_states` 구독 후 프레임 타임스탬프 기준으로 관절 데이터 정렬
- `ParquetWriter` — explicit pyarrow schema로 LeRobot 포맷 Parquet 파일 작성 (`observation.state`, `action`, `next.done`, `next.reward`, `language_instruction` 등)
- `MetadataService` — `info.json` / `episodes.jsonl` 원자적 관리. 카메라 역할별 video feature 자동 등록

**UI**
- `DataCollectionPanel`: 카메라 프리뷰 그리드, 관절 상태 프로그레스 바, 3-2-1 카운트다운 오버레이, 수집 후 인코딩·업로드 모달 진행 다이얼로그
- `DatasetSettingPanel`에 Dataset Name(타임스탬프 자동생성), 카메라 역할→토픽 콤보박스(top/wrist), Language Instruction 필드 추가

**테스트**
- `JointStateCollector`, `ParquetWriter`, `MetadataService` 단위 테스트 추가

### 수정
- `UploadService` — `upload_episode()`(비디오+parquet 병렬 업로드), `upload_meta()`(메타 디렉토리 전체 업로드), `content_type` 파라미터 추가
- `ApiClient` — auth/token 갱신 로직 제거, presigned URL 요청에 `content_type` 전달
- `MainWindow` — 로그인 플로우(LoginWebView, QStackedWidget) 제거, 메인 레이아웃 단순화
- `CameraNode` — 25 → 30 FPS, 재연결 시도 간격 2초 백오프 추가

### 버그 수정
- `CameraNode` — 카메라 읽기 실패 시 매 프레임마다 error 로그가 쌓이던 문제 수정 (재연결 간격 백오프)
- `CameraSubscriberNode` — 5초 이상 프레임 없는 토픽은 stale로 간주해 목록에서 제외
- `UploadService` / `ApiClient` / `server/objects.py` — presigned URL에 `content_type` 미전달로 인한 S3 403 오류 수정
- `DatasetSettingPanel` — Submit 시 Dataset Name을 타임스탬프로 갱신해 S3 경로 중복 방지

### 의존성
- pyarrow, pandas, ffmpeg Dockerfile/requirements.txt에 추가

## Design / Considerations (설계 & 고민한 점)
- **Queue 기반 producer/consumer**: 수집이 진행되는 동안 이전 에피소드 인코딩·업로드가 병렬 실행됨 (`asyncio.gather`). 전체 수집 시간 단축
- **PNG 온디스크 버퍼링**: 프레임을 메모리가 아닌 디스크에 저장해 긴 녹화에서 OOM 방지
- **원자적 JSON 쓰기**: `tmp → os.replace` 패턴으로 프로세스 종료 시 metadata 파일 손상 방지
- **AV1 우선, H264 폴백**: `ffmpeg -encoders` 확인 후 `libsvtav1` 없으면 `libx264`로 자동 전환

## How to Test (테스트 방법)
1. `robot/` 디렉토리에서 Docker 빌드 후 컨테이너 실행
2. Dataset Setting 패널에서 카메라 역할(top, wrist)에 토픽 지정, Language Instruction 입력 후 Submit
3. Data Collection 패널에서 카메라 프리뷰 및 관절 상태 바 정상 표시 확인
4. Record 버튼 클릭 → 3-2-1 카운트다운 → 수집 → 인코딩·업로드 모달 팝업 확인
5. S3에 `{dataset_name}/videos/`, `{dataset_name}/data/`, `{dataset_name}/meta/` 구조로 업로드 확인
6. 단위 테스트: `cd robot && python -m pytest src/robot_ui/test/`

## Impact / Risk (영향도 & 리스크)
- 기존 `RecordingService`는 유지되며 `MultiCameraRecordingService`가 추가됨 — 기존 단일 카메라 녹화 플로우에 직접 영향 없음
- `ApiClient`에서 auth/token 갱신 로직 제거 — presigned URL 요청이 인증 없이 동작하도록 변경됨. (데이터 저장 테스트에 집중하기 위함)
- `content_type` 서버 API 변경(`server/app/schemas/object.py` 등) — 기존 클라이언트가 `content_type` 없이 요청하면 서버 동작 확인 필요

## Related Issues
- Closes #6 
- Closes #7 
- Closes #8 
- Closes #12 
- Closes #13 